### PR TITLE
Improve waitForElement

### DIFF
--- a/woocommerce-sequracheckout/templates/header-js.php
+++ b/woocommerce-sequracheckout/templates/header-js.php
@@ -146,18 +146,10 @@ var SequraHelper = {
 				return resolve();
 			}
 			const observer = new MutationObserver(function(mutations) {
-				mutations.forEach(function(mutation) {
-					if (!mutation.addedNodes)
-						return;
-					var found = false;
-					mutation.addedNodes.forEach(function(node){
-							found = found || (node.matches && node.matches(selector));
-					});
-					if(found) {
-						resolve();
-						observer.disconnect();
-					}
-				});
+				if (document.querySelector(selector)) {
+					resolve();
+					observer.disconnect();
+				}
 			});
 			observer.observe(document.body, {
 				childList: true,

--- a/woocommerce-sequracheckout/templates/partpayment-teaser.php
+++ b/woocommerce-sequracheckout/templates/partpayment-teaser.php
@@ -25,9 +25,11 @@
 			dest = custom_dest;
 		}
 		<?php } ?>
-		SequraHelper.drawPromotionWidget(the_price_container, dest, sq_product, theme, 0, campaign, <?php echo esc_js( $registration_amount ); ?>);
-		Sequra.onLoad(function () {
-			Sequra.refreshComponents();
+		SequraHelper.waitForElement(the_price_container).then(function() {
+			SequraHelper.waitForElement(dest).then(function() {
+				SequraHelper.drawPromotionWidget(the_price_container, dest, sq_product, theme, 0, campaign, <?php echo esc_js( $registration_amount ); ?>);
+				Sequra.onLoad(Sequra.refreshComponents);
+			});
 		});
 	}
 
@@ -38,9 +40,7 @@
 		}
 		var price_in_cents = SequraHelper.selectorToCents(the_price_container);
 		jQuery('[data-product=<?php echo esc_js( $product ); ?>]').attr('data-amount', price_in_cents);
-		Sequra.onLoad(function () {
-			Sequra.refreshComponents();
-		});
+		Sequra.onLoad(Sequra.refreshComponents);
 	}
 
 	document.addEventListener("DOMContentLoaded", function () {

--- a/woocommerce-sequracheckout/woocommerce-sequracheckout.php
+++ b/woocommerce-sequracheckout/woocommerce-sequracheckout.php
@@ -3,11 +3,11 @@
  * Plugin Name: Checkout con SeQura
  * Plugin URI: http://sequra.es/
  * Description: Ofrece las opciones de pago de SeQura
- * Version: 1.1.7
+ * Version: 1.1.8
  * Author: SeQura Engineering
  * Author URI: http://SeQura es/
  * WC requires at least: 4.0
- * WC tested up to: 6.3.1
+ * WC tested up to: 6.6.0
  * Icon1x: https://live.sequracdn.com/assets/images/badges/invoicing.svg
  * Icon2x: https://live.sequracdn.com/assets/images/badges/invoicing_l.svg
  * BannerHigh: https://live.sequracdn.com/assets/images/logos/logo.svg


### PR DESCRIPTION
Previous waitForElement checked if the added node matched the selector.

Sometimes the result is not the expected one because whe don't know how the nodes are added to the DOM. I might happend that the node we are waiting for is not addeddirectly but it is a descendant of one of the added nodes.

With the change we just check if the selector is present in the DOM each time a node is added.