### PR TITLE
Fix settings breaks when no payment method is defined

### DIFF
--- a/sequra/assets/js/src/core/GeneralSettingsForm.js
+++ b/sequra/assets/js/src/core/GeneralSettingsForm.js
@@ -255,7 +255,8 @@ if (!window.SequraFE) {
          */
         const getPaymentMethodOptions = () => {
             const options = [{ label: "None", value: "" }];
-            data.shopPaymentMethods.map((shopPaymentMethod) => {
+            const paymentMethods = data.shopPaymentMethods ? data.shopPaymentMethods : [];
+            paymentMethods.map((shopPaymentMethod) => {
                 options.push({
                     label: shopPaymentMethod.name.charAt(0).toUpperCase() + shopPaymentMethod.name.slice(1),
                     value: shopPaymentMethod.code

--- a/sequra/assets/js/src/core/PaymentController.js
+++ b/sequra/assets/js/src/core/PaymentController.js
@@ -168,6 +168,9 @@ if (!window.SequraFE) {
          * @returns {TableCell[][]}
          */
         const getTableRows = () => {
+            if (!paymentMethods) {
+                return [];
+            }
             return paymentMethods.map((method) => {
                 return [
                     {

--- a/sequra/assets/js/src/core/WidgetSettingsForm.js
+++ b/sequra/assets/js/src/core/WidgetSettingsForm.js
@@ -310,10 +310,10 @@ if (!window.SequraFE) {
                     return `
                     <div class="sq-table__row-field-wrapper">
                         <label class="sq-table__row-field-label">${SequraFE.translationService.translate('widgets.locations.paymentMethod')}</label>
-                        <select class="sq-table__row-field">${allPaymentMethods.map((pm, idx) => {
+                        <select class="sq-table__row-field">${allPaymentMethods ? allPaymentMethods.map((pm, idx) => {
                         const selected = data && data.product === pm.product && data.country === pm.countryCode ? ' selected' : '';
                         return `<option key="${idx}" data-country-code="${pm.countryCode}" data-product="${pm.product}"${selected}>${pm.title}</option>`;
-                    }).join('')}
+                    }).join('') : ''}
                         </select>
                     </div>
                     <div class="sq-table__row-field-wrapper sq-table__row-field-wrapper--grow">
@@ -326,8 +326,8 @@ if (!window.SequraFE) {
                     table.querySelectorAll('.sq-table__row-content').forEach(row => {
                         const select = row.querySelector('select');
                         const sel_for_target = row.querySelector('input').value;
-                        const product = select.options[select.selectedIndex].dataset.product;
-                        const country = select.options[select.selectedIndex].dataset.countryCode;
+                        const product = select.selectedIndex === -1 ? null : select.options[select.selectedIndex].dataset.product;
+                        const country = select.selectedIndex === -1 ? null : select.options[select.selectedIndex].dataset.countryCode;
                         customLocations.push({ sel_for_target, product, country });
                     });
                     handleChange('customLocations', customLocations)


### PR DESCRIPTION
### What is the goal?

Fix settings breaks when no payment method is defined

### References

- **Issue:** PAR-431

### How is it being implemented?

Validate that the payment methods array is not null before calling the map method

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment
