### PR TITLE
Fix selector in header-js.php to use textContent instead of innerText

### DIFF
--- a/sequra/templates/header-js.php
+++ b/sequra/templates/header-js.php
@@ -50,7 +50,7 @@
 		},
 		drawnWidgets: [],
 		getText: function(selector) {
-			return selector && document.querySelector(selector) ? document.querySelector(selector).innerText : "0";
+			return selector && document.querySelector(selector) ? document.querySelector(selector).textContent : "0";
 		},
 
 		selectorToCents: function(selector) {


### PR DESCRIPTION
### What is the goal?

In some scenarios the widgets on the product page show 0 as their value, ignoring the current product value. The issue affects webs having an initial transition of the opacity/visibility of the content, passing from invisible to visible, and it is triggered because the use of innerText instead of textContent function in the JS code.

The main difference between those two functions is that innerText returns the visible text of a DOM node. At the time the script is executed the content is not visible, due the transition mentioned before, and the function returns ''.

### References

- **Issue:** PAR-435

### How is it being implemented?

Change code to use textContent function instead innerText

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment
