### PR TITLE
Prevent JSON content in logs from being escaped

### DIFF
--- a/sequra/class-sequralogger.php
+++ b/sequra/class-sequralogger.php
@@ -217,7 +217,7 @@ class SequraLogger {
 		}
 
 		if ( is_array( $msg ) || is_object( $msg ) ) {
-			$msg = wp_json_encode( $msg );
+			$msg = wp_json_encode( $msg, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_LINE_TERMINATORS );
 		}
 
 		return $message . $msg;


### PR DESCRIPTION
### What is the goal?

Add flags to wp_json_encode to avoid json content from being escaped in the logs.

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment
