### PR TITLE
Start ngrok when e2e are lauched

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,6 +12,8 @@ MARIADB_USER=exampleuser
 MARIADB_PASSWORD=examplepass
 # The password for the root user
 MARIADB_ROOT_PASSWORD=root
+# The port to expose the WordPress service
+MARIADB_PORT=3326
 # The hostname of the database server
 WORDPRESS_DB_HOST=db
 # For the wp-config.php file. Same as MARIADB_USER
@@ -36,6 +38,8 @@ WP_ADMIN_USER=admin
 WP_ADMIN_PASSWORD=admin 
 # The WordPress wp-admin email
 WP_ADMIN_EMAIL=admin@admin.com
+# The port to expose the WordPress service
+WP_HTTP_PORT=8000
 # The WordPress site URL
 WP_URL=http://localhost.sequrapi.com:8000
 # The WordPress site title

--- a/bin/playwright
+++ b/bin/playwright
@@ -6,16 +6,42 @@ cd "${BASEDIR}"
 bin/composer install --no-dev
 bin/npm run build
 
+cd "${BASEDIR}" || exit
+set -o allexport
+source .env
+set +o allexport
+
+# Get a public domain
+if [[ -z "$NGROK_AUTHTOKEN" ]]; then
+	export NGROK_AUTHTOKEN=$(ngrok config check | grep -Eo 'file at .*' | cut -d' ' -f3 | xargs cat | grep -Eo 'authtoken: .*' | cut -d' ' -f2)
+fi
+if [[ -z "$NGROK_AUTHTOKEN" ]]; then
+	echo "Authtoken is missing. Please enter your ngrok authtoken: (get it from https://dashboard.ngrok.com/)"
+	read -r NGROK_AUTHTOKEN
+fi
+docker run --rm -d -e NGROK_AUTHTOKEN=$NGROK_AUTHTOKEN \
+	-p 4740:4040 \
+	--name ngrok \
+	--add-host=host:host-gateway \
+	ngrok/ngrok:latest \
+	http host:$WP_HTTP_PORT
+
+# Loop until PUBLIC_URL is available
+while [ -z "$PUBLIC_URL" ]; do
+	sleep 2  # Wait for 2 seconds before retrying
+	echo "Waiting for ngrok to start..."
+	PUBLIC_URL=$(curl -s http://localhost:4740/api/tunnels | jq -r '.tunnels[0].public_url')
+done
+docker compose exec web wp --allow-root search-replace $WP_URL $PUBLIC_URL
+echo "Your site is now available at $PUBLIC_URL"
+
 # Check if --headed is passed
 if [[ "$@" == *"--headed"* ]]; then
-
-    set -o allexport
-    source .env
-    set +o allexport
-
+	export WP_URL=$PUBLIC_URL
     cd sequra && npx playwright test $@
 else
     docker run \
     --env-file "${BASEDIR}"/.env \
+	-e WP_URL=$PUBLIC_URL \
     -it --rm -v "${BASEDIR}"/sequra:/app -w /app mcr.microsoft.com/playwright:v1.45.0-jammy bash -c "npx playwright test $@"
 fi


### PR DESCRIPTION
### What is the goal?

Lauch ngrok automatically before starting e2 tests.

### References


### Definition of done


### How is it being implemented?

Launch ngrok using the official docker and local ngrok's credentials.
Query the ngrok API to get the assigned public url and set it in wordpress.

### Opportunistic refactorings

### Caveats

Could be interesting to add ngrok to docker-compose.yml

### How is it tested?

Manual tests

### How is it going to be deployed?
sd
