### PR TITLE
Fix fatal error due wrong argument type, must be of the type array and string given

### DIFF
--- a/sequra/src/Controllers/Hooks/Product/class-product-controller.php
+++ b/sequra/src/Controllers/Hooks/Product/class-product-controller.php
@@ -113,8 +113,9 @@ class Product_Controller extends Controller implements Interface_Product_Control
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
 	 */
-	public function do_widget_shortcode( array $atts ): string {
+	public function do_widget_shortcode( $atts ): string {
 		$this->logger->log_info( 'Shortcode called', __FUNCTION__, __CLASS__ );
+		$atts = (array) $atts;
 		
 		// Check for required attributes.
 		foreach ( array( 'product', 'product_id' ) as $required ) {
@@ -183,9 +184,12 @@ class Product_Controller extends Controller implements Interface_Product_Control
 
 	/**
 	 * Handle the cart widget shortcode callback
+	 * 
+	 * @param array<string, string> $atts The shortcode attributes
 	 */
-	public function do_cart_widget_shortcode( array $atts ): string {
+	public function do_cart_widget_shortcode( $atts ): string {
 		$this->logger->log_info( 'Shortcode called', __FUNCTION__, __CLASS__ );
+		$atts = (array) $atts;
 
 		$current_country = $this->i18n->get_current_country();
 
@@ -243,9 +247,12 @@ class Product_Controller extends Controller implements Interface_Product_Control
 
 	/**
 	 * Handle the product listing widget shortcode callback
+	 * 
+	 * @param array<string, string> $atts The shortcode attributes
 	 */
-	public function do_product_listing_widget_shortcode( array $atts ): string {
+	public function do_product_listing_widget_shortcode( $atts ): string {
 		$this->logger->log_info( 'Shortcode called', __FUNCTION__, __CLASS__ );
+		$atts = (array) $atts;
 
 		$current_country = $this->i18n->get_current_country();
 		

--- a/sequra/src/Controllers/Hooks/Product/interface-product-controller.php
+++ b/sequra/src/Controllers/Hooks/Product/interface-product-controller.php
@@ -17,18 +17,24 @@ interface Interface_Product_Controller {
 
 	/**
 	 * Handle the widget shortcode callback
+	 * 
+	 * @param array<string, string> $atts The shortcode attributes
 	 */
-	public function do_widget_shortcode( array $atts ): string;
+	public function do_widget_shortcode( $atts ): string;
 
 	/**
 	 * Handle the cart widget shortcode callback
+	 * 
+	 * @param array<string, string> $atts The shortcode attributes
 	 */
-	public function do_cart_widget_shortcode( array $atts ): string;
+	public function do_cart_widget_shortcode( $atts ): string;
 
 	/**
 	 * Handle the product listing widget shortcode callback
+	 * 
+	 * @param array<string, string> $atts The shortcode attributes
 	 */
-	public function do_product_listing_widget_shortcode( array $atts ): string;
+	public function do_product_listing_widget_shortcode( $atts ): string;
 	
 	/**
 	 * Add [sequra_widget] to product page automatically


### PR DESCRIPTION
### What is the goal?

Fix for bug detected in WordPress 6.4.5

### References

- **Issue:** [TIJ-342](https://sequra.atlassian.net/browse/TIJ-342)

### Definition of done

Somehow WordPress is passing an empty string as `$atts` parameter instead of an array when `do_shortcode` is called. That triggers a fatal error due the attribute is typed as an array in the method signature. This patch removes the type in the signature and moves it to the PHPDoc block instead. Also a cast operation is performed to avoid further errors. 

### How is it being implemented?

### Opportunistic refactorings

### Caveats

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment


[TIJ-342]: https://sequra.atlassian.net/browse/TIJ-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ