### PR TITLE
Uncaught type error in remove footer admin

### DIFF
--- a/sequra/src/Controllers/Hooks/Settings/class-settings-controller.php
+++ b/sequra/src/Controllers/Hooks/Settings/class-settings-controller.php
@@ -101,8 +101,10 @@ class Settings_Controller extends Controller implements Interface_Settings_Contr
 
 	/**
 	 * Removes the WP footer message
+	 * 
+	 * @param string $text The footer text.
 	 */
-	public function remove_footer_admin( string $text ): string {
+	public function remove_footer_admin( $text ): string {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		if ( ! $this->configuration->is_settings_page() ) {
 			return $text;

--- a/sequra/src/Controllers/Hooks/Settings/interface-settings-controller.php
+++ b/sequra/src/Controllers/Hooks/Settings/interface-settings-controller.php
@@ -41,8 +41,10 @@ interface Interface_Settings_Controller {
 
 	/**
 	 * Removes the WP footer message
+	 * 
+	 * @param string $text The footer text.
 	 */
-	public function remove_footer_admin( string $text ): string;
+	public function remove_footer_admin( $text ): string;
 
 	/**
 	 * Show row meta on the plugin screen.


### PR DESCRIPTION
### What is the goal?

Fix an Uncaught type error detected in one of the methods of the Settings controller due a typed parameter. Seems that the error is triggered by a custom/plugin code that is being executed first and is returning null instead of a string, which is the correct type for the parameter according to the documentation

### References

- **Issue:** TIJ-440

### Definition of done

Move type from parameter to the PHPDoc block section

### How is it being implemented?

### Opportunistic refactorings

### Caveats

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
