### PR TITLE
Move type definitions from every method signature to phpdoc block in Controllers

### DIFF
--- a/glue-plugins/sequra-no-address/src/class-plugin.php
+++ b/glue-plugins/sequra-no-address/src/class-plugin.php
@@ -57,8 +57,10 @@ class Plugin {
 
 	/**
 	 * Initialize the plugin.
+	 * 
+	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 		if ( ! class_exists( 'SeQura\Core\Infrastructure\ServiceRegister' ) ) {
 			$this->show_error( 'seQura - No Address Addon requires seQura to be installed and active.' );
 			return;
@@ -103,8 +105,9 @@ class Plugin {
 	 * Add the addon version to the platform version.
 	 * 
 	 * @param string $version Original platform version.
+	 * @return string
 	 */
-	public function update_platform_version( $version ): string {
+	public function update_platform_version( $version ) {
 		return sprintf( '%s + %s %s', $version, $this->addon_data['Name'], $this->addon_data['Version'] );
 	}
 

--- a/sequra/src/Controllers/Hooks/Asset/class-assets-controller.php
+++ b/sequra/src/Controllers/Hooks/Asset/class-assets-controller.php
@@ -122,8 +122,10 @@ class Assets_Controller extends Controller implements Interface_Assets_Controlle
 
 	/**
 	 * Enqueue styles and scripts in WP-Admin
+	 * 
+	 * @return void
 	 */
-	public function enqueue_admin(): void {
+	public function enqueue_admin() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		if ( ! $this->configuration->is_settings_page() ) {
 			return;
@@ -379,8 +381,10 @@ class Assets_Controller extends Controller implements Interface_Assets_Controlle
 
 	/**
 	 * Enqueue styles and scripts in Front-End
+	 * 
+	 * @return void
 	 */
-	public function enqueue_front(): void {
+	public function enqueue_front() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		if ( is_checkout() || $this->is_order_pay_page() ) {
 			$this->enqueue_front_checkout();

--- a/sequra/src/Controllers/Hooks/Asset/interface-assets-controller.php
+++ b/sequra/src/Controllers/Hooks/Asset/interface-assets-controller.php
@@ -15,11 +15,15 @@ interface Interface_Assets_Controller {
 
 	/**
 	 * Enqueue styles and scripts in WP-Admin
+	 * 
+	 * @return void
 	 */
-	public function enqueue_admin(): void;
+	public function enqueue_admin();
 
 	/**
 	 * Enqueue styles and scripts in Front-End
+	 * 
+	 * @return void
 	 */
-	public function enqueue_front(): void;
+	public function enqueue_front();
 }

--- a/sequra/src/Controllers/Hooks/I18n/class-i18n-controller.php
+++ b/sequra/src/Controllers/Hooks/I18n/class-i18n-controller.php
@@ -48,8 +48,10 @@ class I18n_Controller extends Controller implements Interface_I18n_Controller {
 
 	/**
 	 * Load the plugin text domain for translation.
+	 * 
+	 * @return void
 	 */
-	public function load_text_domain(): void {
+	public function load_text_domain() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		load_plugin_textdomain( $this->text_domain, false, $this->domain_path );
 	}

--- a/sequra/src/Controllers/Hooks/I18n/interface-i18n-controller.php
+++ b/sequra/src/Controllers/Hooks/I18n/interface-i18n-controller.php
@@ -17,6 +17,8 @@ interface Interface_I18n_Controller {
 
 	/**
 	 * Load the plugin text domain for translation.
+	 * 
+	 * @return void
 	 */
-	public function load_text_domain(): void;
+	public function load_text_domain();
 }

--- a/sequra/src/Controllers/Hooks/Order/class-order-controller.php
+++ b/sequra/src/Controllers/Hooks/Order/class-order-controller.php
@@ -49,7 +49,7 @@ class Order_Controller extends Controller implements Interface_Order_Controller 
 	 * @param WC_Order_Data_Store_CPT $order_data_store WC_Order_Data_Store instance.
 	 * @return array modified $query
 	 */
-	public function handle_custom_query_vars( array $wp_query_args, array $query_vars, $order_data_store ): array {
+	public function handle_custom_query_vars( $wp_query_args, $query_vars, $order_data_store ) {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$custom_query_vars = array( 
 			$this->order_service->get_sent_to_sequra_meta_key(),
@@ -71,8 +71,15 @@ class Order_Controller extends Controller implements Interface_Order_Controller 
 
 	/**
 	 * Trigger the sync of the order status with SeQura
+	 * 
+	 * @param int $order_id Order ID.
+	 * @param string $old_status Old status.
+	 * @param string $new_status New status.
+	 * @param WC_Order $order Order object.
+	 * 
+	 * @return void
 	 */
-	public function handle_order_status_changed( int $order_id, string $old_status, string $new_status, WC_Order $order ): void {
+	public function handle_order_status_changed( $order_id, $old_status, $new_status, $order ) {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		try {
 			$this->order_service->update_sequra_order_status( $order, $old_status, $new_status );
@@ -104,15 +111,19 @@ class Order_Controller extends Controller implements Interface_Order_Controller 
 
 	/**
 	 * Get the transient key for notices related to an order
+	 * 
+	 * @param int $order_id Order ID.
 	 */
-	private function get_notices_transient( int $order_id ): string {
+	private function get_notices_transient( $order_id ): string {
 		return 'sequra_notices_order_' . $order_id;
 	}
 
 	/**
 	 * Display notices related to an order
+	 * 
+	 * @return void
 	 */
-	public function display_notices(): void {
+	public function display_notices() {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! is_admin() || ! isset( $_GET['post'], $_GET['action'] ) || 'edit' !== $_GET['action'] ) {
 			return;
@@ -137,8 +148,11 @@ class Order_Controller extends Controller implements Interface_Order_Controller 
 
 	/**
 	 * Show a link to the seQura back office in the order details page
+	 * 
+	 * @param WC_Order $order Order object.
+	 * @return void
 	 */
-	public function show_link_to_sequra_back_office( WC_Order $order ): void {
+	public function show_link_to_sequra_back_office( $order ): void {
 		$args = array(
 			'sequra_link' => $this->order_service->get_link_to_sequra_back_office( $order ),
 		);

--- a/sequra/src/Controllers/Hooks/Order/interface-order-controller.php
+++ b/sequra/src/Controllers/Hooks/Order/interface-order-controller.php
@@ -24,20 +24,32 @@ interface Interface_Order_Controller {
 	 * @param WC_Order_Data_Store_CPT $order_data_store WC_Order_Data_Store instance.
 	 * @return array modified $query
 	 */
-	public function handle_custom_query_vars( array $wp_query_args, array $query_vars, $order_data_store ): array;
+	public function handle_custom_query_vars( $wp_query_args, $query_vars, $order_data_store );
 
 	/**
 	 * Trigger the sync of the order status with SeQura
+	 * 
+	 * @param int $order_id Order ID.
+	 * @param string $old_status Old status.
+	 * @param string $new_status New status.
+	 * @param WC_Order $order Order object.
+	 * 
+	 * @return void
 	 */
-	public function handle_order_status_changed( int $order_id, string $old_status, string $new_status, WC_Order $order ): void;
+	public function handle_order_status_changed( $order_id, $old_status, $new_status, $order );
 
 	/**
 	 * Display notices related to an order
+	 * 
+	 * @return void
 	 */
-	public function display_notices(): void;
+	public function display_notices();
 
 	/**
 	 * Show a link to the seQura back office in the order details page
+	 * 
+	 * @param WC_Order $order Order object.
+	 * @return void
 	 */
-	public function show_link_to_sequra_back_office( WC_Order $order ): void;
+	public function show_link_to_sequra_back_office( $order );
 }

--- a/sequra/src/Controllers/Hooks/Payment/class-payment-controller.php
+++ b/sequra/src/Controllers/Hooks/Payment/class-payment-controller.php
@@ -47,7 +47,7 @@ class Payment_Controller extends Controller implements Interface_Payment_Control
 	 * @param string[] $gateways
 	 * @return string[]
 	 */
-	public function register_gateway_classes( $gateways ): array {
+	public function register_gateway_classes( $gateways ) {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		if ( ! in_array( Sequra_Payment_Gateway::class, $gateways, true ) ) {
 			$gateways[] = Sequra_Payment_Gateway::class;
@@ -57,16 +57,21 @@ class Payment_Controller extends Controller implements Interface_Payment_Control
 
 	/**
 	 * Register the payment gateway block so that it can be used by Gutenberg
+	 * 
+	 * @return void
 	 */
-	public function register_gateway_gutenberg_block(): void {
+	public function register_gateway_gutenberg_block() {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_gateway_gutenberg_block_class' ) );
 	}
 
 	/**
 	 * Register the payment gateway block class
+	 * 
+	 * @param PaymentMethodRegistry $payment_method_registry The payment method registry.
+	 * @return void
 	 */
-	public function register_gateway_gutenberg_block_class( PaymentMethodRegistry $payment_method_registry ): void {
+	public function register_gateway_gutenberg_block_class( $payment_method_registry ) {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$payment_method_registry->register( ServiceRegister::getService( Sequra_Payment_Gateway_Block_Support::class ) );
 	}
@@ -74,9 +79,11 @@ class Payment_Controller extends Controller implements Interface_Payment_Control
 	/**
 	 * Append text after the thank you message on the order received page
 	 * 
+	 * @param string $text The text to append.
 	 * @param mixed $order The order object.
+	 * @return string
 	 */
-	public function order_received_text( string $text, $order ): string {
+	public function order_received_text( $text, $order ) {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$notices = wc_print_notices( true );
 		return $notices . $text;
@@ -85,9 +92,11 @@ class Payment_Controller extends Controller implements Interface_Payment_Control
 	/**
 	 * Set the proper payment method description in the order
 	 * 
+	 * @param string $value The payment method title.
 	 * @param mixed $order The order object.
+	 * @return string
 	 */
-	public function order_get_payment_method_title( string $value, $order ): string {
+	public function order_get_payment_method_title( $value, $order ) {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$sequra_payment_method = $order instanceof WC_Order ? $this->order_service->get_payment_method_title( $order ) : null;
 		return empty( $sequra_payment_method ) ? $value : $sequra_payment_method;

--- a/sequra/src/Controllers/Hooks/Payment/interface-payment-controller.php
+++ b/sequra/src/Controllers/Hooks/Payment/interface-payment-controller.php
@@ -21,29 +21,38 @@ interface Interface_Payment_Controller {
 	 * @param string[] $gateways
 	 * @return string[]
 	 */
-	public function register_gateway_classes( $gateways ): array;
+	public function register_gateway_classes( $gateways );
 
 	/**
 	 * Register the payment gateway block so that it can be used by Gutenberg
+	 * 
+	 * @return void
 	 */
-	public function register_gateway_gutenberg_block(): void;
+	public function register_gateway_gutenberg_block();
 
 	/**
 	 * Register the payment gateway block class
+	 * 
+	 * @param PaymentMethodRegistry $payment_method_registry The payment method registry.
+	 * @return void
 	 */
-	public function register_gateway_gutenberg_block_class( PaymentMethodRegistry $payment_method_registry ): void;
+	public function register_gateway_gutenberg_block_class( $payment_method_registry );
 
 	/**
 	 * Append text after the thank you message on the order received page
 	 * 
+	 * @param string $text The text to append.
 	 * @param mixed $order The order object.
+	 * @return string
 	 */
-	public function order_received_text( string $text, $order ): string;
+	public function order_received_text( $text, $order );
 
 	/**
 	 * Set the proper payment method description in the order
 	 * 
+	 * @param string $value The payment method title.
 	 * @param mixed $order The order object.
+	 * @return string
 	 */
-	public function order_get_payment_method_title( string $value, $order ): string;
+	public function order_get_payment_method_title( $value, $order );
 }

--- a/sequra/src/Controllers/Hooks/Process/class-async-process-controller.php
+++ b/sequra/src/Controllers/Hooks/Process/class-async-process-controller.php
@@ -39,8 +39,10 @@ class Async_Process_Controller extends Controller implements Interface_Async_Pro
 
 	/**
 	 * Send the delivery report
+	 * 
+	 * @return void
 	 */
-	public function send_delivery_report(): void {
+	public function send_delivery_report() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		try {
 			$this->report_service->send_delivery_report_for_current_store();

--- a/sequra/src/Controllers/Hooks/Process/interface-async-process-controller.php
+++ b/sequra/src/Controllers/Hooks/Process/interface-async-process-controller.php
@@ -15,6 +15,8 @@ interface Interface_Async_Process_Controller {
 
 	/**
 	 * Send the delivery report
+	 * 
+	 * @return void
 	 */
-	public function send_delivery_report(): void;
+	public function send_delivery_report();
 }

--- a/sequra/src/Controllers/Hooks/Product/class-product-controller.php
+++ b/sequra/src/Controllers/Hooks/Product/class-product-controller.php
@@ -112,8 +112,9 @@ class Product_Controller extends Controller implements Interface_Product_Control
 	 * - theme: The theme to use. Accepted values are: L, R, legacy, legacyL, legacyR, minimal, minimalL, minimalR or JSON formatted string. Optional.
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
+	 * @return string
 	 */
-	public function do_widget_shortcode( $atts ): string {
+	public function do_widget_shortcode( $atts ) {
 		$this->logger->log_info( 'Shortcode called', __FUNCTION__, __CLASS__ );
 		$atts = (array) $atts;
 		
@@ -186,8 +187,9 @@ class Product_Controller extends Controller implements Interface_Product_Control
 	 * Handle the cart widget shortcode callback
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
+	 * @return string
 	 */
-	public function do_cart_widget_shortcode( $atts ): string {
+	public function do_cart_widget_shortcode( $atts ) {
 		$this->logger->log_info( 'Shortcode called', __FUNCTION__, __CLASS__ );
 		$atts = (array) $atts;
 
@@ -249,8 +251,9 @@ class Product_Controller extends Controller implements Interface_Product_Control
 	 * Handle the product listing widget shortcode callback
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
+	 * @return string
 	 */
-	public function do_product_listing_widget_shortcode( $atts ): string {
+	public function do_product_listing_widget_shortcode( $atts ) {
 		$this->logger->log_info( 'Shortcode called', __FUNCTION__, __CLASS__ );
 		$atts = (array) $atts;
 
@@ -372,8 +375,10 @@ class Product_Controller extends Controller implements Interface_Product_Control
 	/**
 	 * Add [sequra_widget] to product page automatically
 	 * Add [sequra_cart_widget] to cart page automatically
+	 * 
+	 * @return void
 	 */
-	public function add_widget_shortcode_to_page(): void {
+	public function add_widget_shortcode_to_page() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		if ( did_action( 'before_woocommerce_sequra_add_widget_to_page' ) ) {
 			return;
@@ -393,15 +398,20 @@ class Product_Controller extends Controller implements Interface_Product_Control
 
 	/**
 	 * Add meta boxes to the product edit page
+	 * 
+	 * @return void
 	 */
-	public function add_meta_boxes(): void {
+	public function add_meta_boxes() {
 		add_meta_box( 'sequra_settings', esc_html__( 'seQura settings', 'sequra' ), array( $this, 'render_meta_boxes' ), 'product', 'side', 'default' );
 	}
 
 	/**
 	 * Render the meta boxes
+	 * 
+	 * @param WP_Post $post The post object
+	 * @return void
 	 */
-	public function render_meta_boxes( WP_Post $post ): void {
+	public function render_meta_boxes( $post ) {
 		$args = array(
 			'is_banned'                                    => $this->product_service->is_banned( $post->ID ),
 			'is_banned_field_name'                         => self::FIELD_NAME_IS_BANNED,
@@ -425,8 +435,11 @@ class Product_Controller extends Controller implements Interface_Product_Control
 
 	/**
 	 * Save product meta
+	 * 
+	 * @param int $post_id The post ID
+	 * @return void
 	 */
-	public function save_product_meta( int $post_id ): void {
+	public function save_product_meta( $post_id ) {
 		if ( ! isset( $_POST[ self::NONCE_SEQURA_PRODUCT ] ) 
 		|| ! wp_verify_nonce( $_POST[ self::NONCE_SEQURA_PRODUCT ], -1 ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		|| ! current_user_can( 'edit_post', $post_id )

--- a/sequra/src/Controllers/Hooks/Product/interface-product-controller.php
+++ b/sequra/src/Controllers/Hooks/Product/interface-product-controller.php
@@ -19,41 +19,54 @@ interface Interface_Product_Controller {
 	 * Handle the widget shortcode callback
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
+	 * @return string
 	 */
-	public function do_widget_shortcode( $atts ): string;
+	public function do_widget_shortcode( $atts );
 
 	/**
 	 * Handle the cart widget shortcode callback
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
+	 * @return string
 	 */
-	public function do_cart_widget_shortcode( $atts ): string;
+	public function do_cart_widget_shortcode( $atts );
 
 	/**
 	 * Handle the product listing widget shortcode callback
 	 * 
 	 * @param array<string, string> $atts The shortcode attributes
+	 * @return string
 	 */
-	public function do_product_listing_widget_shortcode( $atts ): string;
+	public function do_product_listing_widget_shortcode( $atts );
 	
 	/**
 	 * Add [sequra_widget] to product page automatically
 	 * Add [sequra_cart_widget] to cart page automatically
+	 * 
+	 * @return void
 	 */
-	public function add_widget_shortcode_to_page(): void;
+	public function add_widget_shortcode_to_page();
 
 	/**
 	 * Add meta boxes to the product edit page
+	 * 
+	 * @return void
 	 */
-	public function add_meta_boxes(): void;
+	public function add_meta_boxes();
 
 	/**
 	 * Render the meta boxes
+	 * 
+	 * @param WP_Post $post The post object
+	 * @return void
 	 */
-	public function render_meta_boxes( WP_Post $post ): void;
+	public function render_meta_boxes( $post );
 
 	/**
 	 * Save product meta
+	 * 
+	 * @param int $post_id The post ID
+	 * @return void
 	 */
-	public function save_product_meta( int $post_id ): void;
+	public function save_product_meta( $post_id );
 }

--- a/sequra/src/Controllers/Hooks/Settings/class-settings-controller.php
+++ b/sequra/src/Controllers/Hooks/Settings/class-settings-controller.php
@@ -45,8 +45,10 @@ class Settings_Controller extends Controller implements Interface_Settings_Contr
 
 	/**
 	 * Register the settings page.
+	 * 
+	 * @return void
 	 */
-	public function register_page(): void {
+	public function register_page() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		add_submenu_page(
 			$this->configuration->get_parent_page(),
@@ -65,16 +67,21 @@ class Settings_Controller extends Controller implements Interface_Settings_Contr
 
 	/**
 	 * Render the settings page.
+	 * 
+	 * @return void
 	 */
-	public function render_page(): void {
+	public function render_page() {
 		$this->logger->log_info( 'Callback executed', __FUNCTION__, __CLASS__ );
 		wc_get_template( 'admin/settings_page.php', array(), '', $this->templates_path );
 	}
 
 	/**
 	 * Get the settings page URL.
+	 * 
+	 * @param string|null $url The URL.
+	 * @return string
 	 */
-	public function get_settings_page_url( ?string $url = null ): string {
+	public function get_settings_page_url( $url = null ) {
 		return admin_url( 'admin.php?page=' . $this->configuration->get_page() );
 	}
 
@@ -85,9 +92,9 @@ class Settings_Controller extends Controller implements Interface_Settings_Contr
 	 * @param string   $plugin_file The plugin file.
 	 * @param string   $plugin_data The plugin data.
 	 * @param string   $context The context.
-	 * @return mixed[]
+	 * @return string[]
 	 */
-	public function add_action_link( $actions, $plugin_file, $plugin_data, $context ): array {
+	public function add_action_link( $actions, $plugin_file, $plugin_data, $context ) {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$args = array(
 			'href' => $this->get_settings_page_url(),
@@ -103,8 +110,9 @@ class Settings_Controller extends Controller implements Interface_Settings_Contr
 	 * Removes the WP footer message
 	 * 
 	 * @param string $text The footer text.
+	 * @return string
 	 */
-	public function remove_footer_admin( $text ): string {
+	public function remove_footer_admin( $text ) {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		if ( ! $this->configuration->is_settings_page() ) {
 			return $text;
@@ -117,8 +125,9 @@ class Settings_Controller extends Controller implements Interface_Settings_Contr
 	 *
 	 * @param array $links Plugin Row Meta.
 	 * @param string $file  Plugin Base file.
+	 * @return string[]
 	 */
-	public function add_plugin_row_meta( $links, $file ): array {
+	public function add_plugin_row_meta( $links, $file ) {
 		if ( $this->plugin_basename === $file ) {
 			$row_meta = array(
 				'docs'    => sprintf(

--- a/sequra/src/Controllers/Hooks/Settings/interface-settings-controller.php
+++ b/sequra/src/Controllers/Hooks/Settings/interface-settings-controller.php
@@ -15,13 +15,17 @@ interface Interface_Settings_Controller {
 
 	/**
 	 * Register the settings page.
+	 * 
+	 * @return void
 	 */
-	public function register_page(): void;
+	public function register_page();
 
 	/**
 	 * Render the settings page.
+	 * 
+	 * @return void
 	 */
-	public function render_page(): void;
+	public function render_page();
 
 	/**
 	 * Add action links to the plugin settings page.
@@ -32,25 +36,30 @@ interface Interface_Settings_Controller {
 	 * @param string   $context The context.
 	 * @return string[]
 	 */
-	public function add_action_link( $actions, $plugin_file, $plugin_data, $context ): array;
+	public function add_action_link( $actions, $plugin_file, $plugin_data, $context );
 
 	/**
 	 * Get the settings page URL.
+	 * 
+	 * @param string|null $url The URL.
+	 * @return string
 	 */
-	public function get_settings_page_url( ?string $url = null ): string;
+	public function get_settings_page_url( $url = null );
 
 	/**
 	 * Removes the WP footer message
 	 * 
 	 * @param string $text The footer text.
+	 * @return string
 	 */
-	public function remove_footer_admin( $text ): string;
+	public function remove_footer_admin( $text );
 
 	/**
 	 * Show row meta on the plugin screen.
 	 *
 	 * @param array $links Plugin Row Meta.
 	 * @param string $file  Plugin Base file.
+	 * @return string[]
 	 */
-	public function add_plugin_row_meta( $links, $file ): array;
+	public function add_plugin_row_meta( $links, $file );
 }

--- a/sequra/src/Controllers/Rest/class-general-settings-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-general-settings-rest-controller.php
@@ -46,8 +46,10 @@ class General_Settings_REST_Controller extends REST_Controller {
 
 	/**
 	 * Register the API endpoints.
+	 * 
+	 * @return void
 	 */
-	public function register_routes(): void {
+	public function register_routes() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$store_id_args = array( self::PARAM_STORE_ID => $this->get_arg_string() );
 		$general_args  = array_merge(

--- a/sequra/src/Controllers/Rest/class-log-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-log-rest-controller.php
@@ -35,8 +35,10 @@ class Log_REST_Controller extends REST_Controller {
 
 	/**
 	 * Register the API endpoints.
+	 * 
+	 * @return void
 	 */
-	public function register_routes(): void {
+	public function register_routes() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$store_id_args = array( self::PARAM_STORE_ID => $this->get_arg_string() );
 		$conf_args     = array_merge(

--- a/sequra/src/Controllers/Rest/class-onboarding-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-onboarding-rest-controller.php
@@ -69,8 +69,10 @@ class Onboarding_REST_Controller extends REST_Controller {
 
 	/**
 	 * Register the API endpoints.
+	 * 
+	 * @return void
 	 */
-	public function register_routes(): void {
+	public function register_routes() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$store_id_args = array( self::PARAM_STORE_ID => $this->get_arg_string() );
 

--- a/sequra/src/Controllers/Rest/class-payment-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-payment-rest-controller.php
@@ -44,8 +44,10 @@ class Payment_REST_Controller extends REST_Controller {
 
 	/**
 	 * Register the API endpoints.
+	 * 
+	 * @return void
 	 */
-	public function register_routes(): void {
+	public function register_routes() {
 		$this->logger->log_debug( 'Hook executed', __FUNCTION__, __CLASS__ );
 		$data_store_id = array( self::PARAM_STORE_ID => $this->get_arg_string() );
 		$data_methods  = array_merge(

--- a/sequra/src/class-bootstrap.php
+++ b/sequra/src/class-bootstrap.php
@@ -146,10 +146,13 @@ class Bootstrap extends BootstrapComponent {
 		Reg::registerService(
 			Plugin::class,
 			static function () {
+				$env_data = (array) Reg::getService( 'environment.data' );
+				$wc_data  = (array) Reg::getService( 'woocommerce.data' );
+
 				return new Plugin(
 					Reg::getService( 'plugin.data' ),
-					Reg::getService( 'environment.data' )['wp_version'] ?? '',
-					Reg::getService( 'woocommerce.data' )['Version'] ?? '',
+					$env_data['wp_version'] ?? '',
+					$wc_data['Version'] ?? '',
 					Reg::getService( 'plugin.file_path' ),
 					Reg::getService( 'plugin.basename' ),
 					Reg::getService( Interface_Migration_Manager::class ),
@@ -816,11 +819,12 @@ class Bootstrap extends BootstrapComponent {
 			Interface_Assets_Controller::class,
 			static function () {
 				if ( ! isset( self::$cache[ Interface_Assets_Controller::class ] ) ) {
+					$env_data = (array) Reg::getService( 'environment.data' );
 					self::$cache[ Interface_Assets_Controller::class ] = new Assets_Controller(
 						Reg::getService( 'plugin.assets_url' ), 
 						Reg::getService( 'plugin.assets_path' ), 
 						Reg::getService( 'plugin.data' )['Version'],
-						Reg::getService( 'environment.data' )['wp_version'],
+						$env_data['wp_version'] ?? '',
 						Reg::getService( Interface_I18n::class ),
 						Reg::getService( Interface_Logger_Service::class ),
 						Reg::getService( 'plugin.templates_path' ),


### PR DESCRIPTION
### What is the goal?

Remove type definition from method signature to phpdoc bloc on every controller class. This change prevents Uncaught TypeError from being throw when some custom function in the merchant's website listens to one of the hooks used by seQura's plugin (filters mainly) and runs first returning unexpected types.

### References

- **Issue:** TIJ-440

### Definition of done

Remove type definition from method signature to phpdoc bloc on every controller class

### How is it being implemented?

### Opportunistic refactorings

### Caveats

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
