### PR TITLE
Remove solicitation from the payment gateway is_available method

### DIFF
--- a/sequra/src/Controllers/Hooks/Asset/class-assets-controller.php
+++ b/sequra/src/Controllers/Hooks/Asset/class-assets-controller.php
@@ -306,7 +306,7 @@ class Assets_Controller extends Controller implements Interface_Assets_Controlle
 		 */
 		$is_block = apply_filters( 
 			'sequra_is_block_checkout', 
-			! $this->is_order_pay_page() // TODO: Remove this condition once the block checkout is implemented in the order pay page.
+			! $this->payment_method_service->is_order_pay_page() // TODO: Remove this condition once the block checkout is implemented in the order pay page.
 			&& class_exists( 'Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils' ) 
 			&& method_exists( 'Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils', 'is_checkout_block_default' )
 			&& \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_checkout_block_default()
@@ -371,14 +371,7 @@ class Assets_Controller extends Controller implements Interface_Assets_Controlle
 		global $post;
 		return has_shortcode( $post->post_content, 'sequra_product_listing_widget' );
 	}
-
-	/**
-	 * Check if the current page is the order pay page
-	 */
-	private function is_order_pay_page(): bool {
-		return ( (int) strval( get_query_var( 'order-pay' ) ) ) > 0;
-	}
-
+	
 	/**
 	 * Enqueue styles and scripts in Front-End
 	 * 
@@ -386,7 +379,7 @@ class Assets_Controller extends Controller implements Interface_Assets_Controlle
 	 */
 	public function enqueue_front() {
 		$this->logger->log_info( 'Hook executed', __FUNCTION__, __CLASS__ );
-		if ( is_checkout() || $this->is_order_pay_page() ) {
+		if ( $this->payment_method_service->is_checkout() ) {
 			$this->enqueue_front_checkout();
 		} 
 		

--- a/sequra/src/Services/Payment/class-payment-method-service.php
+++ b/sequra/src/Services/Payment/class-payment-method-service.php
@@ -184,11 +184,10 @@ class Payment_Method_Service implements Interface_Payment_Method_Service {
 	 * @return array<string, string>[]
 	 */
 	public function get_payment_methods( ?WC_Order $order = null ): array {
-
 		if ( null !== $this->payment_methods ) {
 			return $this->payment_methods;
 		}
-	
+		// TODO: Implement a cache system to avoid multiple requests with the same payload.
 		$response = $this->request_solicitation( $order );
 
 		if ( ! $response || ! $response->isSuccessful() ) {
@@ -313,5 +312,24 @@ class Payment_Method_Service implements Interface_Payment_Method_Service {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Check if the current page is the order pay page
+	 */
+	public function is_order_pay_page(): bool {
+		return ( (int) strval( get_query_var( 'order-pay' ) ) ) > 0;
+	}
+
+	/**
+	 * Check if the current page is the checkout page
+	 */
+	public function is_checkout(): bool {
+		/**
+		 * Check if current page is checkout
+		 * 
+		 * @since 3.0.0
+		 */
+		return (bool) apply_filters( 'sequra_is_checkout', is_checkout() || $this->is_order_pay_page() || WC()->is_store_api_request() );
 	}
 }

--- a/sequra/src/Services/Payment/class-sequra-payment-gateway.php
+++ b/sequra/src/Services/Payment/class-sequra-payment-gateway.php
@@ -169,13 +169,11 @@ class Sequra_Payment_Gateway extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	public function is_available() {
-		$is_available = parent::is_available();
-		$order        = $this->try_to_get_order_from_context();
+		$is_available = parent::is_available() && $this->payment_method_service->is_checkout();
+		$order        = $is_available ? $this->try_to_get_order_from_context() : null; // skip order retrieval if not available.
+
 		if ( $is_available && ! $this->cart_service->is_available_in_checkout( $order ) ) {
 			$this->logger->log_debug( 'Payment gateway is not available in checkout. Conditions are not met', __FUNCTION__, __CLASS__ );
-			$is_available = false;
-		} elseif ( $is_available && empty( $this->payment_method_service->get_payment_methods( $order ) ) ) {
-			$this->logger->log_debug( 'Payment gateway is not available in checkout. No payment methods available', __FUNCTION__, __CLASS__ );
 			$is_available = false;
 		}
 		/**

--- a/sequra/src/Services/Payment/interface-payment-method-service.php
+++ b/sequra/src/Services/Payment/interface-payment-method-service.php
@@ -56,4 +56,14 @@ interface Interface_Payment_Method_Service {
 	 * @return array<string, string>[]
 	 */
 	public function get_all_mini_widget_compatible_payment_methods( string $store_id, ?string $merchant ): array;
+
+	/**
+	 * Check if the current page is the order pay page
+	 */
+	public function is_order_pay_page(): bool;
+
+	/**
+	 * Check if the current page is the checkout page
+	 */
+	public function is_checkout(): bool;
 }


### PR DESCRIPTION
### What is the goal?

Reduce the amount of request that are sent to Timon for the solicitation step

### Definition of done

Add some checks to validate if the current page is the checkout before start the request. Additionally, the solicitation is only required for showing payment options and not also for the payment gateway `is_available` verification

### How is it being implemented?

Remove unnecessary code from payment gateway.

### Opportunistic refactorings

Refactor code to move utility methods to payment service

### Caveats

### How is it tested?

Automatic tests and Manual tests

### How is it going to be deployed?

Standard deployment
