### PR TITLE
Bugfix for call to undefined method is_store_api_request

### DIFF
--- a/sequra/src/Services/Payment/class-payment-method-service.php
+++ b/sequra/src/Services/Payment/class-payment-method-service.php
@@ -332,6 +332,22 @@ class Payment_Method_Service implements Interface_Payment_Method_Service {
 		 * 
 		 * @since 3.0.0
 		 */
-		return (bool) \apply_filters( 'sequra_is_checkout', \is_checkout() || $this->is_order_pay_page() || WC()->is_store_api_request() );
+		return (bool) \apply_filters( 'sequra_is_checkout', \is_checkout() || $this->is_order_pay_page() || $this->is_store_api_request() );
+	}
+
+	/**
+	 * Returns true if the request is a store REST API request.
+	 *
+	 * @return bool
+	 */
+	private function is_store_api_request() {
+		if ( method_exists( 'WooCommerce', 'is_store_api_request' ) ) {
+			return WC()->is_store_api_request();
+		}
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return false !== strpos( $_SERVER['REQUEST_URI'], trailingslashit( rest_get_url_prefix() ) . 'wc/store/' );
 	}
 }


### PR DESCRIPTION
### What is the goal?

We are relaying on `WooCommerce::is_store_api_request()` method to make some checks in order to reduce the amount of requests made by the plugin to Order API. Seems that this method is not present in every modern WC version what makes the our code fail, throwing a runtime exception.

This PR brings a compatibility layer to prevent this from happening.

### References

- **Issue:** TIJ-551

### Definition of done

Validate if method exists in the current WC version installed and if not use a port of the existing implementation.

### Opportunistic refactorings

### Caveats

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
