### PR TITLE
Function _load_textdomain_just_in_time was called incorrectly

### DIFF
--- a/glue-plugins/sequra-no-address/src/class-bootstrap.php
+++ b/glue-plugins/sequra-no-address/src/class-bootstrap.php
@@ -75,7 +75,7 @@ class Bootstrap {
 						return $headers;
 					};
 					add_filter( 'extra_plugin_headers', $add_wc_headers );
-					$data = get_plugin_data( ServiceRegister::getService( 'noaddress_addon.file_path' ) );
+					$data = get_plugin_data( ServiceRegister::getService( 'noaddress_addon.file_path' ), true, false );
 					remove_filter( 'extra_plugin_headers', $add_wc_headers );
 					
 					$data['RequiresSQ'] = '';

--- a/sequra/src/class-bootstrap.php
+++ b/sequra/src/class-bootstrap.php
@@ -241,7 +241,7 @@ class Bootstrap extends BootstrapComponent {
 					if ( ! function_exists( 'get_plugin_data' ) ) {
 						require_once ABSPATH . 'wp-admin/includes/plugin.php';
 					}
-					self::$cache['woocommerce.data'] = \get_plugin_data( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' );
+					self::$cache['woocommerce.data'] = \get_plugin_data( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php', true, false );
 				}
 				return self::$cache['woocommerce.data'];
 			}
@@ -259,7 +259,7 @@ class Bootstrap extends BootstrapComponent {
 						return $headers;
 					};
 					\add_filter( 'extra_plugin_headers', $add_wc_headers );
-					$data = \get_plugin_data( Reg::getService( 'plugin.file_path' ) );
+					$data = \get_plugin_data( Reg::getService( 'plugin.file_path' ), true, false );
 					\remove_filter( 'extra_plugin_headers', $add_wc_headers );
 					$data['RequiresWC'] = $data['WC requires at least'];
 					unset( $data['WC requires at least'] );


### PR DESCRIPTION
### What is the goal?

Remove the notice that appears due translation loading changes in WordPress 6.7.  More info at:
https://developer.woocommerce.com/2024/11/11/developer-advisory-translation-loading-changes-in-wordpress-6-7/
https://core.trac.wordpress.org/ticket/44937

### How is it being implemented?

Pass `translate = false` when retrieving the plugin data in Bootstrap. Otherwise, `load_plugin_textdomain` is triggered by the WordPress Core resulting in a notice like this:

```
PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>sequra</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6114, referer: https://068521da2ff5.ngrok.app/wp-admin/plugins.php
```

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
