### PR TITLE
Feature/par 556 port fix to delay the checkout js execution

### DIFF
--- a/sequra/assets/js/src/page/checkout.js
+++ b/sequra/assets/js/src/page/checkout.js
@@ -33,7 +33,7 @@
          * @returns {string|null}
          */
         getCheckedPaymentOpt: function () {
-            if ('undefined' === typeof SeQuraCheckout) {
+            if ('undefined' === typeof SeQuraCheckout || 'undefined' === typeof SeQuraCheckout.selectedPaymentMethod) {
                 return null
             }
             return SeQuraCheckout.selectedPaymentMethod;

--- a/sequra/assets/js/src/page/checkout.js
+++ b/sequra/assets/js/src/page/checkout.js
@@ -12,9 +12,33 @@
 
             if (this.isJQueryActive()) {
                 jQuery(document.body).on('updated_checkout', e => {
-                    this.bindEvents()
+                    if(!this.isUpdatedCheckoutListenerDelayed()) {
+                        this.bindEvents();
+                        return;
+                    }
+                    
+                    setTimeout(() => this.bindEvents(), this.getUpdatedCheckoutListenerDelay());
                 });
             }
+        },
+
+        /**
+         * Verifies if the updated checkout listener is delayed. Defaults to false if not defined.
+         * 
+         * @returns {boolean}
+         */
+        isUpdatedCheckoutListenerDelayed: function () {
+            return 'undefined' === typeof SeQuraCheckout || 'undefined' === typeof SeQuraCheckout.isUpdatedCheckoutListenerDelayed ? false : !!SeQuraCheckout.isUpdatedCheckoutListenerDelayed;
+        },
+
+        /**
+         * Returns the delay for the updated checkout listener. Defaults to 0 if not defined.
+         * 
+         * @returns {number}
+         */
+        getUpdatedCheckoutListenerDelay: function () {
+            const delay = 'undefined' === typeof SeQuraCheckout || 'undefined' === typeof SeQuraCheckout.updatedCheckoutListenerDelay ? 0 : parseInt(SeQuraCheckout.updatedCheckoutListenerDelay, 10);
+            return Number.isNaN(delay) ? 0 : delay;
         },
 
         /**

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -107,6 +107,9 @@ Contributors:
 * Added: Filter to set the start time for running database migrations.
 * Added: Filter to set the end time for running database migrations.
 * Added: Filter to set how many entities will be processed every time the database migration runs.
+* Added: Filter for delaying the execution of the listener for the WooCommerce updated_checkout JS event.
+* Added: Filter to set the delay in milliseconds of the listener for the WooCommerce updated_checkout JS event.
+
 = 3.1.1	=
 * Fixed: Use WC Order ID from notification parameters for retrieving the Order for confirmation at seQura.
 * Fixed: Error that prevents the process that handles the deletion of old seQura order data from running.

--- a/sequra/src/Controllers/Hooks/Asset/class-assets-controller.php
+++ b/sequra/src/Controllers/Hooks/Asset/class-assets-controller.php
@@ -322,11 +322,31 @@ class Assets_Controller extends Controller implements Interface_Assets_Controlle
 			&& \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_checkout_block_default()
 		);
 
+		/**
+		 * Set the flag to delay the updated checkout event listener
+		 * 
+		 * @since 3.2.0
+		 * @param bool $is_updated_checkout_listener_delayed
+		 * @return bool
+		 */
+		$is_updated_checkout_listener_delayed = (bool) apply_filters( 'sequra_is_updated_checkout_listener_delayed', false );
+
+		/**
+		 * Set the delay for the updated checkout event listener in milliseconds
+		 * 
+		 * @since 3.2.0
+		 * @param int $updated_checkout_listener_delay
+		 * @return int
+		 */
+		$updated_checkout_listener_delay = (int) apply_filters( 'sequra_updated_checkout_listener_delay', 0 );
+
 		\wp_localize_script(
 			self::HANDLE_CHECKOUT,
 			'SeQuraCheckout',
 			array(
-				'isBlockCheckout' => $is_block,
+				'isBlockCheckout'                  => $is_block,
+				'isUpdatedCheckoutListenerDelayed' => $is_updated_checkout_listener_delayed,
+				'updatedCheckoutListenerDelay'     => $updated_checkout_listener_delay,
 			) 
 		);
 		\wp_enqueue_script( self::HANDLE_CHECKOUT );


### PR DESCRIPTION
### What is the goal?

Port the solution provided [here](https://sequra.atlassian.net/issues/TIJ-1511) so it can be enabled and used for other merchants if it's needed

### References

- **Issue:** PAR-556

### How is it being implemented?

This pull request introduces functionality to delay the execution of the WooCommerce `updated_checkout` JavaScript event listener and set a custom delay duration. The changes include updates to the JavaScript logic, new filters for customization, and documentation updates.

### Enhancements to JavaScript Event Handling:
* Modified `sequra/assets/js/src/page/checkout.js` to conditionally delay the execution of the `updated_checkout` event listener. Added two new methods, `isUpdatedCheckoutListenerDelayed` and `getUpdatedCheckoutListenerDelay`, to determine whether the listener is delayed and to retrieve the delay duration.

### Backend Filters for Customization:
* Added two new filters in `sequra/src/Controllers/Hooks/Asset/class-assets-controller.php`:
  - `sequra_is_updated_checkout_listener_delayed`: Allows toggling the delay for the `updated_checkout` listener.
  - [`sequra_updated_checkout_listener_delay`](diffhunk://#diff-24865863cd49bff3e837895c299d1e241005cf521a0f3e1738be52131106306cR325-R349): Sets the delay duration in milliseconds. These values are passed to the frontend via `wp_localize_script`.

### Documentation Updates:
* Updated `sequra/readme.txt` to document the new filters for delaying the `updated_checkout` listener and setting the delay duration.

### Opportunistic refactorings

* Updated the `getCheckedPaymentOpt` method in `sequra/assets/js/src/page/checkout.js` to handle cases where `SeQuraCheckout.selectedPaymentMethod` is undefined.


### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment
