### PR TITLE
feature/PAR-569 Add order notes for refund errors

### DIFF
--- a/sequra/src/Services/Payment/class-sequra-payment-gateway.php
+++ b/sequra/src/Services/Payment/class-sequra-payment-gateway.php
@@ -560,22 +560,27 @@ class Sequra_Payment_Gateway extends WC_Payment_Gateway {
 	 * @return bool|\WP_Error True or false based on success, or a WP_Error object.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
-		$amount = (float) $amount;
-		if ( $amount <= 0 ) {
-			$this->logger->log_debug( 'Invalid refund amount: ' . $amount, __FUNCTION__, __CLASS__ );
-			return new WP_Error( 'empty_refund_amount', __( 'Refund amount cannot be empty', 'sequra' ) );
-		}
 		$order = \wc_get_order( $order_id );
 		if ( ! $order instanceof WC_Order ) {
 			$this->logger->log_error( 'Order not found', __FUNCTION__, __CLASS__, array( new LogContextData( 'order_id', $order_id ) ) );
 			return new WP_Error( 'order_not_found', __( 'Order not found', 'sequra' ) );
 		}
+		$amount = (float) $amount;
+		if ( $amount <= 0 ) {
+			$message = __( 'Refund amount cannot be empty', 'sequra' );
+			$order->add_order_note( $message );
+			$this->logger->log_debug( 'Invalid refund amount: ' . $amount, __FUNCTION__, __CLASS__ );
+			return new WP_Error( 'empty_refund_amount', $message );
+		}
 		try {
 			$this->order_service->handle_refund( $order, $amount );
 			return true;
 		} catch ( Throwable $e ) {
+			// translators: %s is the error message.
+			$message = sprintf( esc_html__( 'Refund failed in seQura: %s', 'sequra' ), $e->getMessage() );
+			$order->add_order_note( $message );
 			$this->logger->log_throwable( $e, __FUNCTION__, __CLASS__ );
-			return new WP_Error( 'refund_failed', __( 'An error occurred while refunding the order in seQura.', 'sequra' ) ); // TODO: improve message.
+			return new WP_Error( 'refund_failed', $message );
 		}
 	}
 }


### PR DESCRIPTION
### What is the goal?

Enhance refund process by adding order notes for invalid amounts and exceptions

### References

- **Issue:** PAR-569

### How is it being implemented?

This pull request updates the `process_refund` method in the `SequraPaymentGateway` class to improve error handling and logging during refund processing. The changes enhance the clarity of error messages and ensure that order notes are added when specific errors occur.

#### Improvements to error handling and logging:

* Added functionality to log a detailed error message and add an order note when the refund amount is invalid, providing better feedback for debugging and customer support. (`sequra/src/Services/Payment/class-sequra-payment-gateway.php`, [sequra/src/Services/Payment/class-sequra-payment-gateway.phpL563-R583](diffhunk://#diff-6a96dac7fbc56bce4d1112884858eb501002fc80a1f0c5741a67ba1582fa84c7L563-R583))
* Enhanced error message formatting for refund failures, including the specific error details, and ensured the message is added as an order note for better traceability. (`sequra/src/Services/Payment/class-sequra-payment-gateway.php`, [sequra/src/Services/Payment/class-sequra-payment-gateway.phpL563-R583](diffhunk://#diff-6a96dac7fbc56bce4d1112884858eb501002fc80a1f0c5741a67ba1582fa84c7L563-R583))

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
