### PR TITLE
Chore/PAR-576 Automatically publishing of the release zip on GitHub

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,8 +10,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Execute make_zip script
         run: |
-          ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra --filename=sequra.zip
-          ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra-no-address --filename=sequra-no-address.zip
+          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra --filename=sequra.zip
+          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra-no-address --filename=sequra-no-address.zip
       - name: Attach ZIP file to release
         run: |
           cd zip

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,12 +8,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Execute make_zip script
+      - name: Make ZIP files
         run: |
-          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra --filename=sequra.zip
-          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra-no-address --filename=sequra-no-address.zip
-      - name: Attach ZIP file to release
-        run: |
+          echo "⚙️ Installing Composer dependencies"
+          bin/composer --no-dev --quiet --no-interaction
+          echo "⚙️ Installing NPM dependencies and building"
+          bin/npm install --no-progress --no-update-notifier
+          bin/npm run build --no-progress --no-update-notifier
+          echo "🧹 Removing unwanted files"
+          rm -Rf sequra/node_modules
+          rm -Rf sequra/tests
+          rm -Rf sequra/tests-e2e
+          rm -Rf sequra/apigen
+          rm -f sequra/.gitignore glue-plugins/sequra-no-address/.gitignore
+          rm -f sequra/package.json
+          rm -f sequra/package-lock.json
+          rm -f sequra/composer.json glue-plugins/sequra-no-address/composer.json
+          rm -f sequra/composer.lock glue-plugins/sequra-no-address/composer.lock
+          rm -f sequra/.phpcs.xml.dist glue-plugins/sequra-no-address/.phpcs.xml.dist
+          rm -f sequra/babel.config.json
+          rm -f sequra/phpstan.neon glue-plugins/sequra-no-address/phpstan.neon
+          rm -f sequra/phpunit.xml.dist
+          rm -f sequra/playwright.config.js
+          rm -f sequra/postcss.config.js
+          rm -f sequra/*.log
+          rm -f sequra/webpack.config.js
+          echo "📦 Creating ZIP files"
+          mkdir -p zip
+          cd sequra
+          zip -r9 ../zip/sequra.zip .
+          cd ../glue-plugins/sequra-no-address
+          zip -r9 ../zip/sequra-no-address.zip .
+          echo "📎 Attaching ZIP files to the release"
           cd zip
           release_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r .id)
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/zip" --data-binary @sequra.zip "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=sequra-${{ github.ref_name }}.zip"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  release:
+    types: [created]
+jobs:
+  execute_buildzip_script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Execute make_zip script
+        run: |
+          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra --filename=sequra.zip
+          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra-no-address --filename=sequra-no-address.zip
+      - name: Attach ZIP file to release
+        run: |
+          cd zip
+          release_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r .id)
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/zip" --data-binary @sequra.zip "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=sequra-${{ github.ref_name }}.zip"
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/zip" --data-binary @sequra-no-address.zip "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=sequra-no-address-${{ github.ref_name }}.zip"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,13 +34,12 @@ jobs:
           rm -f sequra/*.log
           rm -f sequra/webpack.config.js
           echo "📦 Creating ZIP files"
-          mkdir -p zip
-          cd sequra
-          zip -r9 ../zip/sequra.zip .
-          cd ../glue-plugins/sequra-no-address
-          zip -r9 ../zip/sequra-no-address.zip .
+          zip -r9 sequra.zip sequra
+          cd glue-plugins
+          zip -r9 sequra-no-address.zip sequra-no-address
+          mv sequra-no-address.zip ../sequra-no-address.zip
           echo "📎 Attaching ZIP files to the release"
-          cd zip
+          cd ..
           release_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r .id)
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/zip" --data-binary @sequra.zip "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=sequra-${{ github.ref_name }}.zip"
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/zip" --data-binary @sequra-no-address.zip "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=sequra-no-address-${{ github.ref_name }}.zip"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Make ZIP files
         run: |
           echo "⚙️ Installing Composer dependencies"
-          bin/composer --no-dev --quiet --no-interaction
+          bin/composer install --no-dev --quiet --no-interaction
           echo "⚙️ Installing NPM dependencies and building"
           bin/npm install --no-progress --no-update-notifier
           bin/npm run build --no-progress --no-update-notifier

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,8 +10,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Execute make_zip script
         run: |
-          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra --filename=sequra.zip
-          bash ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra-no-address --filename=sequra-no-address.zip
+          ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra --filename=sequra.zip
+          ./bin/make_zip --branch=${{ github.ref_name }} --project=sequra-no-address --filename=sequra-no-address.zip
       - name: Attach ZIP file to release
         run: |
           cd zip

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ jobs:
           bin/npm install --no-progress --no-update-notifier
           bin/npm run build --no-progress --no-update-notifier
           echo "🧹 Removing unwanted files"
-          rm -Rf sequra/node_modules
+          sudo rm -Rf sequra/node_modules
           rm -Rf sequra/tests
           rm -Rf sequra/tests-e2e
           rm -Rf sequra/apigen

--- a/bin/make_zip
+++ b/bin/make_zip
@@ -32,7 +32,7 @@ echo "Creating a zip file for the \"$PROJECT\" project using branch \"$BRANCH\""
 
 GITHUB_REPO_OWNER="sequra"
 GITHUB_REPO_NAME="woocommerce-sequra"
-GIT_REPO="git@github.com:"${GITHUB_REPO_OWNER}"/"${GITHUB_REPO_NAME}".git"
+GIT_REPO="https://github.com/"${GITHUB_REPO_OWNER}"/"${GITHUB_REPO_NAME}".git"
 BASEDIR="$(dirname $(realpath $0))/.."
 
 mkdir -p "$BASEDIR/zip" || true

--- a/bin/make_zip
+++ b/bin/make_zip
@@ -5,6 +5,8 @@
 PROJECT="sequra"
 # Argument --branch. Name of the Git branch to checkout
 BRANCH="master"
+# Argument --filename. Optional. Name of the zip file to create
+FILENAME=""
 
 while [[ "$#" -gt 0 ]]; do
     if [[ "$1" == --project=* ]]; then
@@ -17,6 +19,11 @@ while [[ "$#" -gt 0 ]]; do
 
     elif [[ "$1" == --branch=* ]]; then
         BRANCH="${1#*=}"
+    elif [[ "$1" == --filename=* ]]; then
+        FILENAME="${1#*=}"
+        if [[ "$FILENAME" != *.zip ]]; then
+            FILENAME="$FILENAME.zip"
+        fi
     fi
     shift
 done
@@ -74,7 +81,11 @@ rm -f webpack.config.js
 cd ..
 
 echo "Creating the zip file..."
-FILENAME="$PROJECT-$PLUGIN_VERSION-$COMMIT_HASH.zip"
+
+if [ -z "$FILENAME" ]; then
+    FILENAME="$PROJECT-$PLUGIN_VERSION-$COMMIT_HASH.zip"
+fi
+
 zip -r9 $FILENAME "$PROJECT"
 mv $FILENAME "$BASEDIR/zip"
 cd "$BASEDIR/zip"

--- a/bin/make_zip
+++ b/bin/make_zip
@@ -50,8 +50,8 @@ echo "Installing dependencies and building the project..."
 bin/composer install --no-dev --quiet --no-interaction
 
 if [[ "$PROJECT" == "sequra" ]]; then
-    bin/npm install --no-progress --silent --no-update-notifier
-    bin/npm run build --no-progress --silent --no-update-notifier
+    bin/npm install --no-progress --no-update-notifier
+    bin/npm run build --no-progress --no-update-notifier
     cd "$PROJECT"
 elif [[ "$PROJECT" == "sequra-no-address" ]]; then
     cd "glue-plugins/$PROJECT"

--- a/bin/npm
+++ b/bin/npm
@@ -1,3 +1,3 @@
 #!/bin/bash
 BASEDIR="$(dirname $(realpath $0))/.."
-docker run --rm -v "$BASEDIR"/sequra:/app -w /app -u $(id -u):$(id -g) node:20-alpine npm $@
+docker run --rm -v "$BASEDIR"/sequra:/app -w /app node:20-alpine npm $@

--- a/bin/npm
+++ b/bin/npm
@@ -1,3 +1,3 @@
 #!/bin/bash
 BASEDIR="$(dirname $(realpath $0))/.."
-docker run --rm -v "$BASEDIR"/sequra:/app -w /app node:20-alpine npm $@
+docker run --rm -v "$BASEDIR"/sequra:/app -w /app -u $(id -u):$(id -g) node:20-alpine npm $@


### PR DESCRIPTION
### What is the goal?

Automatically publishing of the release zip on GitHub

### References

- **Issue:** PAR-576

### How is it being implemented?

This pull request introduces a new GitHub Actions workflow to automate the build and release process by creating ZIP files and attaching them to a GitHub release.

#### New GitHub Actions workflow:

* [`.github/workflows/build-release.yml`](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R1-R45): Added a `Build` workflow triggered by the creation of a release. The workflow includes steps to install dependencies, build the project, remove unnecessary files, create ZIP files for distribution, and upload them as assets to the release.

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment
