### PR TITLE
Release 3.2.1

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,9 +1,9 @@
 # The version of MariaDB to use. See available tags at https://hub.docker.com/_/mariadb/tags
 MARIADB_TAG=latest
 # The version of WordPress to use. See available tags at https://hub.docker.com/_/wordpress/tags 
-WP_TAG=6.8.1
+WP_TAG=6.8.2
 # The version of WooCommerce to use. See available versions https://wordpress.org/plugins/woocommerce/advanced/ 
-WC_VERSION=9.8.5
+WC_VERSION=10.0.2
 # The name of the database to create
 MARIADB_DATABASE=exampledb
 # The name of the database user to create

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -2,8 +2,8 @@
 Contributors: sequradev
 Tags: woocommerce, payment gateway, BNPL, installments, buy now pay later
 Requires at least: 5.9
-Tested up to: 6.8.1
-Stable tag: 3.2.0
+Tested up to: 6.8.2
+Stable tag: 3.2.1
 Requires PHP: 7.3
 License: GPL-3.0+
 License URI: https://www.gnu.org/licenses/gpl-3.0.txt
@@ -100,6 +100,10 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 Contributors:
 == Changelog ==
+= 3.2.1	=
+* Fixed: Allow sequra_order table to be created when migration is running if it does not exists but sequra_order_legacy table does.
+* Changed: Tested up to WordPress 6.8.2 and WooCommerce 10.0.2
+
 = 3.2.0	=
 * Added: Filter to allow modifying the locale.
 * Added: SeQura orders are now indexed on new installations.

--- a/sequra/sequra.php
+++ b/sequra/sequra.php
@@ -8,7 +8,7 @@
  * Plugin Name:       seQura
  * Plugin URI:        https://sequra.es/
  * Description:       seQura payment gateway for WooCommerce
- * Version:           3.2.0
+ * Version:           3.2.1
  * Author:            "seQura Tech" <wordpress@sequra.com>
  * Author URI:        https://sequra.com/
  * License:           GPL-3.0+
@@ -17,9 +17,9 @@
  * Domain Path:       /languages
  * Requires PHP:      7.3
  * Requires at least: 5.9
- * Tested up to:      6.8.1
+ * Tested up to:      6.8.2
  * WC requires at least: 4.7.0
- * WC tested up to: 9.8.5
+ * WC tested up to: 10.0.2
  * Requires Plugins:  woocommerce
  */
 


### PR DESCRIPTION
### What is the goal?

Prepare the release 3.2.1

### How is it being implemented?

This pull request updates the plugin to ensure compatibility with the latest versions of WordPress and WooCommerce, while also addressing a migration issue. The most important changes include version updates for dependencies, plugin metadata adjustments, and a bug fix in the changelog.

#### Dependency version updates:
* [`.env.sample`](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL4-R6): Updated `WP_TAG` to `6.8.2` and `WC_VERSION` to `10.0.2` to align with the latest WordPress and WooCommerce versions.

#### Plugin metadata adjustments:
* [`sequra/readme.txt`](diffhunk://#diff-abb2d5436ad8da26dbec1fb11818570d92b12ace314b1c2fa092096617824bc3L5-R6): Updated "Tested up to" to WordPress `6.8.2` and "Stable tag" to `3.2.1`.
* [`sequra/sequra.php`](diffhunk://#diff-9e4c8982c393395ac48eae47c039466cf0f2a6880238418d0a6f776411778ef9L11-R11): Updated plugin version to `3.2.1` and adjusted compatibility metadata for WordPress `6.8.2` and WooCommerce `10.0.2`. [[1]](diffhunk://#diff-9e4c8982c393395ac48eae47c039466cf0f2a6880238418d0a6f776411778ef9L11-R11) [[2]](diffhunk://#diff-9e4c8982c393395ac48eae47c039466cf0f2a6880238418d0a6f776411778ef9L20-R22)

#### Bug fix:
* [`sequra/readme.txt`](diffhunk://#diff-abb2d5436ad8da26dbec1fb11818570d92b12ace314b1c2fa092096617824bc3R103-R106): Added a changelog entry for version `3.2.1`, which includes a fix to ensure the `sequra_order` table is created during migration if the `sequra_order_legacy` table exists.

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
