### PR TITLE
Bugfix/PAR-585 Ensure that the order completion date can be retrieved

### DIFF
--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -100,6 +100,9 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 Contributors:
 == Changelog ==
+= 3.2.2	=
+* Fixed: Ensure that the order completion date can be retrieved.
+
 = 3.2.1	=
 * Fixed: Allow sequra_order table to be created when migration is running if it does not exists but sequra_order_legacy table does.
 * Changed: Tested up to WordPress 6.8.2 and WooCommerce 10.0.2

--- a/sequra/sequra.php
+++ b/sequra/sequra.php
@@ -8,7 +8,7 @@
  * Plugin Name:       seQura
  * Plugin URI:        https://sequra.es/
  * Description:       seQura payment gateway for WooCommerce
- * Version:           3.2.1
+ * Version:           3.2.2-rc.1
  * Author:            "seQura Tech" <wordpress@sequra.com>
  * Author URI:        https://sequra.com/
  * License:           GPL-3.0+

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Integration/OrderReport/class-order-report-service.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Integration/OrderReport/class-order-report-service.php
@@ -114,7 +114,7 @@ class Order_Report_Service implements OrderReportServiceInterface {
 					), // Items.
 					$cart_info ? $cart_info->ref : null,
 					$cart_info ? $cart_info->created_at : null, // Created at.
-					( $order->get_date_completed() ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' ) // Updated At.
+					$this->order_service->get_order_completion_date( $order ) // Updated at.
 				), // Cart.
 				$this->order_service->get_delivery_method( $order ), // Delivery Method.
 				$this->order_service->get_customer( $order, $this->i18n->get_lang() ), // Customer.

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Integration/OrderReport/class-order-report-service.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Integration/OrderReport/class-order-report-service.php
@@ -114,7 +114,7 @@ class Order_Report_Service implements OrderReportServiceInterface {
 					), // Items.
 					$cart_info ? $cart_info->ref : null,
 					$cart_info ? $cart_info->created_at : null, // Created at.
-					$order->get_date_completed()->format( 'Y-m-d H:i:s' ) // Updated At.
+					( $order->get_date_completed() ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' ) // Updated At.
 				), // Cart.
 				$this->order_service->get_delivery_method( $order ), // Delivery Method.
 				$this->order_service->get_customer( $order, $this->i18n->get_lang() ), // Customer.

--- a/sequra/src/Services/Order/class-order-service.php
+++ b/sequra/src/Services/Order/class-order-service.php
@@ -780,7 +780,7 @@ class Order_Service implements Interface_Order_Service {
 		$currency      = $order->get_currency( 'edit' );
 		$cart_ref      = $cart_info ? $cart_info->ref : null;
 		$created_at    = $cart_info ? $cart_info->created_at : null;
-		$updated_at    = $order->get_date_completed()->format( 'Y-m-d H:i:s' );
+		$updated_at    = ( $order->get_date_completed() ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' );
 		$shipped_items = array_merge(
 			$this->cart_service->get_items( $order ),
 			$this->cart_service->get_handling_items( $order ),
@@ -838,7 +838,7 @@ class Order_Service implements Interface_Order_Service {
 		$currency      = $order->get_currency( 'edit' );
 		$cart_ref      = $cart_info ? $cart_info->ref : null;
 		$created_at    = $cart_info ? $cart_info->created_at : null;
-		$updated_at    = $order->get_date_completed()->format( 'Y-m-d H:i:s' );
+		$updated_at    = ( $order->get_date_completed() ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' );
 		$shipped_items = array();
 		if ( $order->get_total( 'edit' ) > $amount ) {
 			$shipped_items = array_merge(

--- a/sequra/src/Services/Order/class-order-service.php
+++ b/sequra/src/Services/Order/class-order-service.php
@@ -780,7 +780,7 @@ class Order_Service implements Interface_Order_Service {
 		$currency      = $order->get_currency( 'edit' );
 		$cart_ref      = $cart_info ? $cart_info->ref : null;
 		$created_at    = $cart_info ? $cart_info->created_at : null;
-		$updated_at    = ( $order->get_date_completed() ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' );
+		$updated_at    = $this->get_order_completion_date( $order );
 		$shipped_items = array_merge(
 			$this->cart_service->get_items( $order ),
 			$this->cart_service->get_handling_items( $order ),

--- a/sequra/src/Services/Order/class-order-service.php
+++ b/sequra/src/Services/Order/class-order-service.php
@@ -982,4 +982,15 @@ class Order_Service implements Interface_Order_Service {
 			}
 		}
 	}
+
+	/**
+	 * Get the order completion date or current date if not completed.
+	 * 
+	 * @param WC_Order $order
+	 * @return string
+	 */
+	public function get_order_completion_date( $order ) {
+		$datetime = $order instanceof WC_Order ? $order->get_date_completed() : null;
+		return ( $datetime ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' );
+	}
 }

--- a/sequra/src/Services/Order/class-order-service.php
+++ b/sequra/src/Services/Order/class-order-service.php
@@ -838,7 +838,7 @@ class Order_Service implements Interface_Order_Service {
 		$currency      = $order->get_currency( 'edit' );
 		$cart_ref      = $cart_info ? $cart_info->ref : null;
 		$created_at    = $cart_info ? $cart_info->created_at : null;
-		$updated_at    = ( $order->get_date_completed() ?? new \WC_DateTime() )->format( 'Y-m-d H:i:s' );
+		$updated_at    = $this->get_order_completion_date( $order );
 		$shipped_items = array();
 		if ( $order->get_total( 'edit' ) > $amount ) {
 			$shipped_items = array_merge(

--- a/sequra/src/Services/Order/interface-order-service.php
+++ b/sequra/src/Services/Order/interface-order-service.php
@@ -251,4 +251,12 @@ interface Interface_Order_Service {
 	 * Execute the migration process
 	 */
 	public function migrate_data();
+
+	/**
+	 * Get the order completion date or current date if not completed.
+	 * 
+	 * @param WC_Order $order
+	 * @return string
+	 */
+	public function get_order_completion_date( $order );
 }

--- a/sequra/tests/Core/BusinessLogic/Domain/Integration/OrderReport/OrderReportServiceTest.php
+++ b/sequra/tests/Core/BusinessLogic/Domain/Integration/OrderReport/OrderReportServiceTest.php
@@ -203,7 +203,7 @@ class OrderReportServiceTest extends WP_UnitTestCase {
 					array(),
 					null,
 					null,
-					$order->get_date_completed()->format( 'Y-m-d H:i:s' )
+					$this->order_service->get_order_completion_date( $order )
 				),
 				$delivery_method,
 				$customer,


### PR DESCRIPTION
### What is the goal?

Ensure that the order completion date can be retrieved by providing the current one if the returned value is `NULL`.

### References

- **Issue:** PAR-585

### How is it being implemented?

This pull request includes updates to improve the handling of order completion dates, ensure compatibility with the latest WordPress and WooCommerce versions, and increment the plugin version. The most important changes include fixing potential null values for order completion dates, updating the plugin version, and adding a changelog entry.

#### Fixes and Improvements to Order Completion Date Handling:
* Updated the `updated_at` field in `getOrderReports`, `set_sequra_order_status_to_shipped`, and `handle_refund` methods to handle potential null values for `get_date_completed()` by defaulting to the current date and time (`\WC_DateTime`). (`[[1]](diffhunk://#diff-30e2582c353b06ad2d76974f29d5095685071dd065ad2e620b84e38d3195b354L117-R117)`, `[[2]](diffhunk://#diff-f8a4314242b895264791957c50fba8ad1af1c666b1dbfea2f5f1a454f43fad09L783-R783)`, `[[3]](diffhunk://#diff-f8a4314242b895264791957c50fba8ad1af1c666b1dbfea2f5f1a454f43fad09L841-R841)`)

#### Plugin Version Update:
* Incremented the plugin version from `3.2.1` to `3.2.2-rc.1` in the main plugin file `sequra.php`. (`[sequra/sequra.phpL11-R11](diffhunk://#diff-9e4c8982c393395ac48eae47c039466cf0f2a6880238418d0a6f776411778ef9L11-R11)`)

#### Documentation Update:
* Added a changelog entry for version `3.2.2` in the `readme.txt` file, noting the fix for retrieving the order completion date. (`[sequra/readme.txtR103-R105](diffhunk://#diff-abb2d5436ad8da26dbec1fb11818570d92b12ace314b1c2fa092096617824bc3R103-R105)`)

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment