### PR TITLE
Bugfix/PAR-588 Onboarding stoped working after the redirection rules for sandbox were enabled

### DIFF
--- a/sequra/assets/js/src/core/ConnectionSettingsForm.js
+++ b/sequra/assets/js/src/core/ConnectionSettingsForm.js
@@ -249,9 +249,7 @@ if (!window.SequraFE) {
                 })
             } else {
                 utilities.showLoader();
-
-                const merchantId = configuration.appState === SequraFE.appStates.ONBOARDING ? 'test' : data.countrySettings[0]?.merchantId;
-                api.post(configuration.validateConnectionDataUrl, { ...changedSettings, merchantId: merchantId }, SequraFE.customHeader)
+                api.post(configuration.validateConnectionDataUrl, changedSettings, SequraFE.customHeader)
                     .then((result) => areCredentialsValid(result) ? saveChangedData() : handleValidationError());
             }
         }

--- a/sequra/src/Controllers/Rest/class-onboarding-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-onboarding-rest-controller.php
@@ -92,7 +92,7 @@ class Onboarding_REST_Controller extends REST_Controller {
 		$validate_data_args = array_merge(
 			$data_args,
 			array(
-				self::PARAM_MERCHANT_ID => $this->get_arg_string(),
+				self::PARAM_MERCHANT_ID => $this->get_arg_string( false ),
 			)
 		);
 


### PR DESCRIPTION
### What is the goal?

Fix the error that appears on the Onboarding credentials screen after the router was enabled on sandbox

### References

- **Issue:** PAR-588

### How is it being implemented?

This pull request simplifies the handling of merchant ID logic in both the frontend and backend code to improve maintainability and consistency. The key changes involve removing conditional logic for assigning a test merchant ID and updating method calls to reflect these adjustments.

#### Frontend Changes:
* [`sequra/assets/js/src/core/ConnectionSettingsForm.js`](diffhunk://#diff-0cdbb277ff072c152cf48274d04c2de71936e151ed4b2045f1a330b86352136aL252-R252): Simplified the `merchantId` handling by removing the conditional logic for assigning a test value during onboarding. The `api.post` call now directly uses `changedSettings` without appending a `merchantId`.

#### Backend Changes:
* [`sequra/src/Controllers/Rest/class-onboarding-rest-controller.php`](diffhunk://#diff-f1d51651f1ab397c457f0649d49668f69b228c632831ccb3c376fdc00284b4ecL95-R95): Updated the `register_routes` method to adjust the `self::PARAM_MERCHANT_ID` argument by passing `false` to the `get_arg_string` method, reflecting the removal of test merchant ID handling.

### How is it tested?

Automatic and manual tests

### How is it going to be deployed?

Standard deployment
