### PR TITLE
[PAR-691] Update playwright-fixture-for-plugins to version 1.2.0

### DIFF
--- a/sequra/package-lock.json
+++ b/sequra/package-lock.json
@@ -21,7 +21,7 @@
                 "babel-loader": "~8.2.0",
                 "css-loader": "~6.7.0",
                 "cssnano": "~5.1.0",
-                "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.1.0",
+                "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.2.0",
                 "postcss-cli": "~9.1.0",
                 "postcss-loader": "~6.2.0",
                 "sass": "~1.49.0",
@@ -17755,8 +17755,9 @@
         },
         "node_modules/playwright-fixture-for-plugins": {
             "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#e226c3b1bac768dae94f0e12b615c4c03468cfd3",
-            "dev": true
+            "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#173b802d61b9034b6def0f8f34c93fc00dba2122",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/playwright/node_modules/fsevents": {
             "version": "2.3.2",

--- a/sequra/package-lock.json
+++ b/sequra/package-lock.json
@@ -17754,7 +17754,7 @@
             }
         },
         "node_modules/playwright-fixture-for-plugins": {
-            "version": "1.1.0",
+            "version": "1.2.0",
             "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#173b802d61b9034b6def0f8f34c93fc00dba2122",
             "dev": true,
             "license": "MIT"

--- a/sequra/package.json
+++ b/sequra/package.json
@@ -46,7 +46,7 @@
         "terser-webpack-plugin": "~5.3.0",
         "webpack": "^5.89.0",
         "webpack-cli": "~4.9.0",
-        "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.1.0"
+        "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.2.0"
     },
     "dependencies": {
         "sequra-core-admin-fe": "github:sequra/integration-core-ui#2.0.0"


### PR DESCRIPTION
### What is the goal?

Update sequra checkout form fixture to match current implementation

### References

- **Issue:** PAR-691

### How is it being implemented?

This pull request updates the `playwright-fixture-for-plugins` development dependency from version 1.1.0 to 1.2.0 in both `package.json` and `package-lock.json`, ensuring the project uses the latest version of this plugin for testing.

Dependency update:

* Updated the `playwright-fixture-for-plugins` package to version 1.2.0 in both `package.json` and `package-lock.json`, which includes a new commit reference and adds license information in the lock file. [[1]](diffhunk://#diff-fe08135f689f1891961a933a5dc55d550804dd6e7c5110232b4f4b3ebce1004cL49-R49) [[2]](diffhunk://#diff-ae1255a791b85f62ac87c6d970c068d40bc215d40f61cbba20bace82eaf146c3L24-R24) [[3]](diffhunk://#diff-ae1255a791b85f62ac87c6d970c068d40bc215d40f61cbba20bace82eaf146c3L17758-R17760)

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment