### PR TITLE
Add job-level concurrency for tunnel-dependent E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -100,33 +100,28 @@ jobs:
           cd sequra
           npx playwright install chromium-headless-shell --with-deps
 
-  e2e-tests:
+  e2e-tests-with-tunnel:
     needs: [composer, npm]
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    
+
+    concurrency:
+      group: e2e-cloudflared-tests
+      cancel-in-progress: false
+
     strategy:
       matrix:
-        suite: ['001', '002', '003', '004', '005', '006']
+        suite: ['001', '002', '003']
         include:
           - suite: '001'
-            cloudflared: true
             tunnel_token_secret: CLOUDFLARED_TUNNEL_TOKEN_001
             tunnel_url_secret: CLOUDFLARED_TUNNEL_URL_001
           - suite: '002'
-            cloudflared: true
             tunnel_token_secret: CLOUDFLARED_TUNNEL_TOKEN_002
             tunnel_url_secret: CLOUDFLARED_TUNNEL_URL_002
           - suite: '003'
-            cloudflared: true
             tunnel_token_secret: CLOUDFLARED_TUNNEL_TOKEN_003
             tunnel_url_secret: CLOUDFLARED_TUNNEL_URL_003
-          - suite: '004'
-            cloudflared: false
-          - suite: '005'
-            cloudflared: false
-          - suite: '006'
-            cloudflared: false
     steps:
       - uses: actions/checkout@v6
 
@@ -156,7 +151,7 @@ jobs:
             sequra/node_modules
             sequra/package-lock.json
           key: sequra-npm-cache-${{ hashFiles('sequra/package-lock.json') }}
-      
+
       - name: Use assets cache
         uses: actions/cache@v5
         id: sequra-assets-cache
@@ -173,8 +168,7 @@ jobs:
             /home/runner/.cache/ms-playwright
           key: playwright-browser-cache-${{ hashFiles('sequra/package-lock.json') }}
 
-      - name: Setup the environment (with cloudflared)
-        if: matrix.cloudflared == true
+      - name: Setup the environment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DUMMY_ASSETS_KEY: ${{ secrets.DUMMY_ASSETS_KEY }}
@@ -191,8 +185,85 @@ jobs:
           sed -i.bak "s|^CLOUDFLARED_TUNNEL_URL=.*|CLOUDFLARED_TUNNEL_URL=$CLOUDFLARED_TUNNEL_URL|" .env && rm .env.bak
           ./setup.sh --cloudflared
 
-      - name: Setup the environment (without cloudflared)
-        if: matrix.cloudflared == false
+      - name: Run E2E tests
+        run: |
+          set -a
+          source .env
+          set +a
+          cd sequra
+          npx playwright test ${{ matrix.suite }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: test-results-${{ matrix.suite }}
+          path: /tmp/test-results
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: ./teardown.sh
+
+  e2e-tests-local:
+    needs: [composer, npm]
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    concurrency:
+      group: e2e-local-tests-${{ github.ref }}
+      cancel-in-progress: true
+
+    strategy:
+      matrix:
+        suite: ['004', '005', '006']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use vendor cache (sequra)
+        uses: actions/cache@v5
+        id: sequra-composer-prod-cache
+        with:
+          path: |
+            sequra/vendor
+            sequra/composer.lock
+          key: sequra-composer-prod-cache-${{ hashFiles('sequra/composer.lock', 'sequra/src/**/*.php') }}
+
+      - name: Use vendor cache (sequra-helper)
+        uses: actions/cache@v5
+        id: sequra-helper-composer-prod-cache
+        with:
+          path: |
+            sequra-helper/vendor
+            sequra-helper/composer.lock
+          key: sequra-helper-composer-prod-cache-${{ hashFiles('sequra-helper/composer.lock', 'sequra-helper/src/**/*.php') }}
+
+      - name: Use node_modules cache
+        uses: actions/cache@v5
+        id: sequra-npm-cache
+        with:
+          path: |
+            sequra/node_modules
+            sequra/package-lock.json
+          key: sequra-npm-cache-${{ hashFiles('sequra/package-lock.json') }}
+
+      - name: Use assets cache
+        uses: actions/cache@v5
+        id: sequra-assets-cache
+        with:
+          path: |
+            sequra/assets
+          key: sequra-assets-cache-${{ hashFiles('sequra/package-lock.json', 'sequra/webpack.config.js', 'sequra/assets/index.php', 'sequra/assets/js/**/*.js', 'sequra/assets/css/**/*.scss') }}
+
+      - name: Use Playwright browser cache
+        uses: actions/cache@v5
+        id: playwright-browser-cache
+        with:
+          path: |
+            /home/runner/.cache/ms-playwright
+          key: playwright-browser-cache-${{ hashFiles('sequra/package-lock.json') }}
+
+      - name: Setup the environment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DUMMY_ASSETS_KEY: ${{ secrets.DUMMY_ASSETS_KEY }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -210,10 +210,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
 
-    concurrency:
-      group: e2e-local-tests-${{ github.ref }}
-      cancel-in-progress: true
-
     strategy:
       matrix:
         suite: ['004', '005', '006']

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,7 @@
 name: E2E tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master
@@ -20,7 +21,7 @@ concurrency:
 jobs:
   composer:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v6
@@ -55,7 +56,7 @@ jobs:
 
   npm:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v6
@@ -103,7 +104,7 @@ jobs:
   e2e-tests-with-tunnel:
     needs: [composer, npm]
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
 
     concurrency:
       group: e2e-cloudflared-tests-${{ matrix.suite }}
@@ -208,7 +209,7 @@ jobs:
   e2e-tests-local:
     needs: [composer, npm]
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,7 +106,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     concurrency:
-      group: e2e-cloudflared-tests
+      group: e2e-cloudflared-tests-${{ matrix.suite }}
       cancel-in-progress: false
 
     strategy:


### PR DESCRIPTION
### What is the goal?

Add job-level concurrency for tunnel-dependent E2E tests and allow manual execution of the workflow

### How is it being implemented?
This pull request updates the GitHub Actions workflow for end-to-end (E2E) tests, improving flexibility and reliability. The main changes include enabling manual workflow dispatch, splitting E2E tests into cloudflared and local jobs, updating job conditions, and enhancing test result handling.

**Workflow flexibility and triggering:**

* Added `workflow_dispatch` to allow manual triggering of E2E tests, in addition to running on pull requests to `master`.
* Updated job conditions so E2E jobs run for both non-draft pull requests and manual workflow dispatches. [[1]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L23-R24) [[2]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L58-R59)

**E2E job restructuring:**

* Split the E2E tests into two jobs: `e2e-tests-with-tunnel` (for suites 001-003 using Cloudflared) and `e2e-tests-local` (for suites 004-006 running locally), simplifying matrix configuration and removing the `cloudflared` matrix variable. [[1]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L103-L129) [[2]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L194-R263)

**Test execution and artifact handling:**

* Consolidated environment setup steps and added explicit steps to run Playwright tests, upload test results as artifacts on failure, and clean up resources after tests.

**Caching improvements:**

* Ensured both jobs use caches for Composer dependencies, Node modules, assets, and Playwright browsers to speed up workflow execution.

**Job and step simplification:**

* Removed redundant conditional steps for cloudflared and unified environment setup logic for clarity and maintainability. [[1]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L176-R172) [[2]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L194-R263)

### How is it tested?

Automatic tests

### How is it going to be deployed?

Standard deployment
