### PR TITLE
PAR-773: Update Integration Core StoreIntegration Signature Redesign

### DIFF
--- a/sequra/composer.json
+++ b/sequra/composer.json
@@ -51,8 +51,7 @@
         "php-stubs/woocommerce-stubs": "^8.8"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "require": {
-        "sequra/integration-core": "dev-refactor/PAR-772-StoreIntegration-Signature-Redesign"
+        "sequra/integration-core": "~5.0.0"
     }
 }

--- a/sequra/composer.json
+++ b/sequra/composer.json
@@ -51,7 +51,8 @@
         "php-stubs/woocommerce-stubs": "^8.8"
     },
     "prefer-stable": true,
+    "minimum-stability": "dev",
     "require": {
-        "sequra/integration-core": "v4.1.0"
+        "sequra/integration-core": "dev-refactor/PAR-772-StoreIntegration-Signature-Redesign"
     }
 }

--- a/sequra/composer.lock
+++ b/sequra/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6420cea73e96c08d22b7494ffa837244",
+    "content-hash": "1a79c4ba7bcd0f2d0c9954451c920cba",
     "packages": [
         {
             "name": "sequra/integration-core",
-            "version": "dev-refactor/PAR-772-StoreIntegration-Signature-Redesign",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sequra/integration-core.git",
-                "reference": "156491cacf443ec64778394b85b72583c8b6d8fe"
+                "reference": "d173aa2642541dee5f1de3d99878363f6cb91438"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sequra/integration-core/zipball/156491cacf443ec64778394b85b72583c8b6d8fe",
-                "reference": "156491cacf443ec64778394b85b72583c8b6d8fe",
+                "url": "https://api.github.com/repos/sequra/integration-core/zipball/d173aa2642541dee5f1de3d99878363f6cb91438",
+                "reference": "d173aa2642541dee5f1de3d99878363f6cb91438",
                 "shasum": ""
             },
             "require": {
@@ -45,9 +45,9 @@
             "description": "Core SeQura integration library",
             "support": {
                 "issues": "https://github.com/sequra/integration-core/issues",
-                "source": "https://github.com/sequra/integration-core/tree/refactor/PAR-772-StoreIntegration-Signature-Redesign"
+                "source": "https://github.com/sequra/integration-core/tree/v5.0.0"
             },
-            "time": "2026-04-28T09:14:34+00:00"
+            "time": "2026-04-28T09:32:58+00:00"
         }
     ],
     "packages-dev": [
@@ -3023,10 +3023,8 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
-    "stability-flags": {
-        "sequra/integration-core": 20
-    },
+    "minimum-stability": "stable",
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {},

--- a/sequra/composer.lock
+++ b/sequra/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d212c39140ff720a364e12bab252fb7",
+    "content-hash": "6420cea73e96c08d22b7494ffa837244",
     "packages": [
         {
             "name": "sequra/integration-core",
-            "version": "v4.1.0",
+            "version": "dev-refactor/PAR-772-StoreIntegration-Signature-Redesign",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sequra/integration-core.git",
-                "reference": "9b98daf23741c8d1f4c0652f9709d286ac2039cf"
+                "reference": "bb7729e2b01b3b9060c2a44443d768fb1a7bc966"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sequra/integration-core/zipball/9b98daf23741c8d1f4c0652f9709d286ac2039cf",
-                "reference": "9b98daf23741c8d1f4c0652f9709d286ac2039cf",
+                "url": "https://api.github.com/repos/sequra/integration-core/zipball/bb7729e2b01b3b9060c2a44443d768fb1a7bc966",
+                "reference": "bb7729e2b01b3b9060c2a44443d768fb1a7bc966",
                 "shasum": ""
             },
             "require": {
@@ -45,9 +45,9 @@
             "description": "Core SeQura integration library",
             "support": {
                 "issues": "https://github.com/sequra/integration-core/issues",
-                "source": "https://github.com/sequra/integration-core/tree/v4.1.0"
+                "source": "https://github.com/sequra/integration-core/tree/refactor/PAR-772-StoreIntegration-Signature-Redesign"
             },
-            "time": "2026-03-10T08:45:58+00:00"
+            "time": "2026-04-27T15:24:17+00:00"
         }
     ],
     "packages-dev": [
@@ -3023,8 +3023,10 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {},
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "sequra/integration-core": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {},

--- a/sequra/composer.lock
+++ b/sequra/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sequra/integration-core.git",
-                "reference": "bb7729e2b01b3b9060c2a44443d768fb1a7bc966"
+                "reference": "156491cacf443ec64778394b85b72583c8b6d8fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sequra/integration-core/zipball/bb7729e2b01b3b9060c2a44443d768fb1a7bc966",
-                "reference": "bb7729e2b01b3b9060c2a44443d768fb1a7bc966",
+                "url": "https://api.github.com/repos/sequra/integration-core/zipball/156491cacf443ec64778394b85b72583c8b6d8fe",
+                "reference": "156491cacf443ec64778394b85b72583c8b6d8fe",
                 "shasum": ""
             },
             "require": {
@@ -47,7 +47,7 @@
                 "issues": "https://github.com/sequra/integration-core/issues",
                 "source": "https://github.com/sequra/integration-core/tree/refactor/PAR-772-StoreIntegration-Signature-Redesign"
             },
-            "time": "2026-04-27T15:24:17+00:00"
+            "time": "2026-04-28T09:14:34+00:00"
         }
     ],
     "packages-dev": [

--- a/sequra/src/Repositories/Migrations/class-migration-install-430.php
+++ b/sequra/src/Repositories/Migrations/class-migration-install-430.php
@@ -120,7 +120,7 @@ class Migration_Install_430 extends Migration {
 			$this->get_store_integrations_proxy()->deleteStoreIntegration(
 				new DeleteStoreIntegrationRequest( $connection_data, $old_webhook_url )
 			);
-		} catch ( Throwable $e ) {
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Best-effort: old integration may already be gone on the seQura side.
 		}
 	}
@@ -150,18 +150,21 @@ class Migration_Install_430 extends Migration {
 	 */
 	private function get_old_webhook_url( string $store_id ): ?string {
 		// @phpstan-ignore-next-line
-		$query = $this->db->prepare(
-			'SELECT `data` FROM ' . $this->entity_table . ' WHERE `type` = %s AND `index_1` = %s LIMIT 1',
-			'StoreIntegration',
-			$store_id
-		);
-		$row   = $this->db->get_row( $query, ARRAY_A );
+		$row = $this->db->get_row( $this->db->prepare( 'SELECT `data` FROM ' . $this->entity_table . ' WHERE `type` = %s AND `index_1` = %s LIMIT 1', 'StoreIntegration', $store_id ), ARRAY_A );
 
 		if ( ! isset( $row['data'] ) || ! \is_string( $row['data'] ) ) {
 			return null;
 		}
 
+		/**
+		 * Decoded entity data.
+		 *
+		 * @var array{storeIntegration?: array{webhookUrl?: string}}|null $data
+		 */
 		$data = json_decode( $row['data'], true );
+		if ( ! is_array( $data ) ) {
+			return null;
+		}
 
 		$url = $data['storeIntegration']['webhookUrl'] ?? null;
 		return \is_string( $url ) && '' !== $url ? $url : null;

--- a/sequra/src/Repositories/Migrations/class-migration-install-430.php
+++ b/sequra/src/Repositories/Migrations/class-migration-install-430.php
@@ -11,12 +11,12 @@ namespace SeQura\WC\Repositories\Migrations;
 use Exception;
 use SeQura\Core\BusinessLogic\Domain\Connection\Services\ConnectionService;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
-use SeQura\Core\BusinessLogic\Domain\StoreIntegration\RepositoryContracts\StoreIntegrationRepositoryInterface;
+use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Models\DeleteStoreIntegrationRequest;
+use SeQura\Core\BusinessLogic\Domain\StoreIntegration\ProxyContracts\StoreIntegrationsProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Services\StoreIntegrationService;
 use SeQura\Core\BusinessLogic\Domain\Stores\Services\StoreService;
 use SeQura\Core\Infrastructure\ServiceRegister;
 use SeQura\WC\Repositories\Interface_Cache_Repository;
-use SeQura\WC\Services\Log\Interface_Logger_Service;
 use Throwable;
 
 /**
@@ -25,18 +25,18 @@ use Throwable;
 class Migration_Install_430 extends Migration {
 
 	/**
-	 * Logger service.
-	 *
-	 * @var Interface_Logger_Service
-	 */
-	private $logger;
-
-	/**
 	 * Store Service
 	 *
 	 * @var StoreService
 	 */
 	private $store_service;
+
+	/**
+	 * Entity table.
+	 *
+	 * @var string
+	 */
+	private $entity_table;
 
 	/**
 	 * Get the plugin version when the changes were made.
@@ -48,19 +48,18 @@ class Migration_Install_430 extends Migration {
 	/**
 	 * Constructor
 	 *
-	 * @param \wpdb                    $wpdb                      Database instance.
-	 * @param Interface_Cache_Repository $cache                   Cache repository.
-	 * @param Interface_Logger_Service $logger                    Logger service.
+	 * @param \wpdb                      $wpdb          Database instance.
+	 * @param Interface_Cache_Repository $cache         Cache repository.
+	 * @param StoreService               $store_service Store service.
 	 */
 	public function __construct(
 		\wpdb $wpdb,
 		Interface_Cache_Repository $cache,
-		StoreService $store_service,
-		Interface_Logger_Service $logger
+		StoreService $store_service
 	) {
 		parent::__construct( $wpdb, $cache );
 		$this->store_service = $store_service;
-		$this->logger        = $logger;
+		$this->entity_table  = $this->db->prefix . 'sequra_entity';
 	}
 
 	/**
@@ -80,19 +79,25 @@ class Migration_Install_430 extends Migration {
 		foreach ( $store_ids as $store_id ) {
 			StoreContext::doWithStore(
 				$store_id,
-				function () use ( &$has_failures ) {
-					foreach ( $this->get_connection_service()->getAllConnectionData() as $connection_data ) {
-						try {
-							if ( null !== $this->get_store_integration_repository()->getStoreIntegration() ) {
-								// Store integration already exists for this store, skipping.   
-								continue;
-							}
+				function () use ( $store_id, &$has_failures ) {
+					$old_webhook_url = $this->get_old_webhook_url( $store_id );
+					$store_failed    = false;
 
+					foreach ( $this->get_connection_service()->getAllConnectionData() as $connection_data ) {
+						if ( null !== $old_webhook_url ) {
+							$this->deregister_old_store_integration( $connection_data, $old_webhook_url );
+						}
+
+						try {
 							$this->get_store_integration_service()->createStoreIntegration( $connection_data );
 						} catch ( Throwable $e ) {
-							$this->logger->log_throwable( $e );
 							$has_failures = true;
+							$store_failed = true;
 						}
+					}
+
+					if ( ! $store_failed ) {
+						$this->delete_old_store_integration_entity( $store_id );
 					}
 				}
 			);
@@ -104,16 +109,62 @@ class Migration_Install_430 extends Migration {
 	}
 
 	/**
-	 * Get store integration repository instance.
+	 * Attempt to deregister the old store integration from the seQura API.
+	 * Non-fatal: exceptions are silently swallowed.
+	 *
+	 * @param \SeQura\Core\BusinessLogic\Domain\Connection\Models\ConnectionData $connection_data
+	 * @param string $old_webhook_url
 	 */
-	private function get_store_integration_repository(): StoreIntegrationRepositoryInterface {
-		/**
-		 * Store integration repository.
-		 *
-		 * @var StoreIntegrationRepositoryInterface $repo
-		 */
-		$repo = ServiceRegister::getService( StoreIntegrationRepositoryInterface::class );
-		return $repo;
+	private function deregister_old_store_integration( $connection_data, string $old_webhook_url ): void {
+		try {
+			$this->get_store_integrations_proxy()->deleteStoreIntegration(
+				new DeleteStoreIntegrationRequest( $connection_data, $old_webhook_url )
+			);
+		} catch ( Throwable $e ) {
+			// Best-effort: old integration may already be gone on the seQura side.
+		}
+	}
+
+	/**
+	 * Remove the old StoreIntegration entity row from the DB.
+	 * Non-fatal: missing rows (0 affected) are silently ignored.
+	 *
+	 * @param string $store_id
+	 */
+	private function delete_old_store_integration_entity( string $store_id ): void {
+		$this->db->delete(
+			$this->entity_table,
+			array(
+				'type'    => 'StoreIntegration',
+				'index_1' => $store_id,
+			)
+		);
+	}
+
+	/**
+	 * Read the old webhook URL from the StoreIntegration entity row in the DB.
+	 * Returns null if no row exists or if the URL cannot be extracted.
+	 *
+	 * @param string $store_id Store identifier.
+	 * @return string|null
+	 */
+	private function get_old_webhook_url( string $store_id ): ?string {
+		// @phpstan-ignore-next-line
+		$query = $this->db->prepare(
+			'SELECT `data` FROM ' . $this->entity_table . ' WHERE `type` = %s AND `index_1` = %s LIMIT 1',
+			'StoreIntegration',
+			$store_id
+		);
+		$row   = $this->db->get_row( $query, ARRAY_A );
+
+		if ( ! isset( $row['data'] ) || ! \is_string( $row['data'] ) ) {
+			return null;
+		}
+
+		$data = json_decode( $row['data'], true );
+
+		$url = $data['storeIntegration']['webhookUrl'] ?? null;
+		return \is_string( $url ) && '' !== $url ? $url : null;
 	}
 
 	/**
@@ -140,5 +191,18 @@ class Migration_Install_430 extends Migration {
 		 */
 		$service = ServiceRegister::getService( StoreIntegrationService::class );
 		return $service;
+	}
+
+	/**
+	 * Get store integrations proxy instance.
+	 */
+	private function get_store_integrations_proxy(): StoreIntegrationsProxyInterface {
+		/**
+		 * Store integrations proxy.
+		 *
+		 * @var StoreIntegrationsProxyInterface $proxy
+		 */
+		$proxy = ServiceRegister::getService( StoreIntegrationsProxyInterface::class );
+		return $proxy;
 	}
 }

--- a/sequra/src/class-bootstrap.php
+++ b/sequra/src/class-bootstrap.php
@@ -154,7 +154,6 @@ use SeQura\WC\Services\Order\Builder\Order_Customer_Builder;
 use SeQura\WC\Services\Order\Builder\Order_Delivery_Method_Builder;
 use SeQura\WC\Services\Service\Interface_Settings_Service;
 use SeQura\WC\Services\Service\Settings_Service;
-use SeQura\Core\BusinessLogic\DataAccess\StoreIntegration\Entities\StoreIntegration;
 use SeQura\Core\BusinessLogic\Domain\Integration\StoreInfo\StoreInfoServiceInterface;
 use SeQura\WC\Core\Implementation\BusinessLogic\Domain\Integration\StoreInfo\Store_Info_Service;
 use SeQura\Core\BusinessLogic\DataAccess\AdvancedSettings\Entities\AdvancedSettings;
@@ -978,7 +977,6 @@ class Bootstrap extends BootstrapComponent {
 		RepositoryRegistry::registerRepository( PaymentMethod::class, Entity_Repository::class );
 		RepositoryRegistry::registerRepository( Credentials::class, Entity_Repository::class );
 		RepositoryRegistry::registerRepository( Deployment::class, Entity_Repository::class );
-		RepositoryRegistry::registerRepository( StoreIntegration::class, Entity_Repository::class );
 		RepositoryRegistry::registerRepository( AdvancedSettings::class, Entity_Repository::class );
 	}
 

--- a/sequra/src/class-bootstrap.php
+++ b/sequra/src/class-bootstrap.php
@@ -623,8 +623,7 @@ class Bootstrap extends BootstrapComponent {
 							new Migration_Install_430(
 								$wpdb,
 								$cache_repository,
-								Reg::getService( StoreService::class ),
-								Reg::getService( Interface_Logger_Service::class )
+								Reg::getService( StoreService::class )
 							),
 						)
 					);

--- a/sequra/tests-e2e/fixtures/pages/CheckoutPage.mjs
+++ b/sequra/tests-e2e/fixtures/pages/CheckoutPage.mjs
@@ -137,7 +137,7 @@ export default class CheckoutPage extends BaseCheckoutPage {
 
         await this.locators.submitCheckout().click();
         // Wait for seQura identification iframe to load (may take longer in CI environments).
-        await this.page.locator(`#sq-identification-${options.product}`).waitFor({ state: 'attached', timeout: 30000 });
+        await this.page.locator(`#sq-identification-${options.product}`).waitFor({ state: 'attached', timeout: 60000 });
         // Fill checkout form.
         switch (options.product) {
             case 'i1':

--- a/sequra/tests/Repositories/Migrations/MigrationInstall430Test.php
+++ b/sequra/tests/Repositories/Migrations/MigrationInstall430Test.php
@@ -233,7 +233,7 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 
 		try {
 			$this->migration->run();
-		} catch ( Exception $e ) {
+		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Expected.
 		}
 

--- a/sequra/tests/Repositories/Migrations/MigrationInstall430Test.php
+++ b/sequra/tests/Repositories/Migrations/MigrationInstall430Test.php
@@ -12,15 +12,16 @@ use Exception;
 use RuntimeException;
 use SeQura\Core\BusinessLogic\Domain\Connection\Models\ConnectionData;
 use SeQura\Core\BusinessLogic\Domain\Connection\Services\ConnectionService;
-use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Models\StoreIntegration;
-use SeQura\Core\BusinessLogic\Domain\StoreIntegration\RepositoryContracts\StoreIntegrationRepositoryInterface;
+use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Models\DeleteStoreIntegrationRequest;
+use SeQura\Core\BusinessLogic\Domain\StoreIntegration\ProxyContracts\StoreIntegrationsProxyInterface;
 use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Services\StoreIntegrationService;
 use SeQura\Core\BusinessLogic\Domain\Stores\Services\StoreService;
 use SeQura\Core\Infrastructure\ServiceRegister;
 use SeQura\WC\Repositories\Cache_Repository;
 use SeQura\WC\Repositories\Migrations\Migration_Install_430;
-use SeQura\WC\Services\Log\Interface_Logger_Service;
 use WP_UnitTestCase;
+
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 
 class MigrationInstall430Test extends WP_UnitTestCase {
 
@@ -39,6 +40,13 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 	private $wpdb;
 
 	/**
+	 * Entity table name.
+	 *
+	 * @var string
+	 */
+	private $entity_table;
+
+	/**
 	 * Connection service mock.
 	 *
 	 * @var ConnectionService&\PHPUnit\Framework\MockObject\MockObject
@@ -53,11 +61,11 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 	private $store_integration_service;
 
 	/**
-	 * Store integration repository mock.
+	 * Store integrations proxy mock.
 	 *
-	 * @var StoreIntegrationRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject
+	 * @var StoreIntegrationsProxyInterface&\PHPUnit\Framework\MockObject\MockObject
 	 */
-	private $store_integration_repository;
+	private $store_integrations_proxy;
 
 	/**
 	 * Store service mock.
@@ -66,27 +74,20 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 	 */
 	private $store_service;
 
-	/**
-	 * Logger service mock.
-	 *
-	 * @var Interface_Logger_Service&\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $logger;
-
 	public function set_up(): void {
 		parent::set_up();
 		global $wpdb;
-		$this->wpdb = $wpdb;
+		$this->wpdb         = $wpdb;
+		$this->entity_table = $wpdb->prefix . 'sequra_entity';
 
-		$this->connection_service           = $this->createMock( ConnectionService::class );
-		$this->store_integration_service    = $this->createMock( StoreIntegrationService::class );
-		$this->store_integration_repository = $this->createMock( StoreIntegrationRepositoryInterface::class );
-		$this->store_service                = $this->createMock( StoreService::class );
-		$this->logger                       = $this->createMock( Interface_Logger_Service::class );
+		$this->connection_service        = $this->createMock( ConnectionService::class );
+		$this->store_integration_service = $this->createMock( StoreIntegrationService::class );
+		$this->store_integrations_proxy  = $this->createMock( StoreIntegrationsProxyInterface::class );
+		$this->store_service             = $this->createMock( StoreService::class );
 
-		$connection_service           = $this->connection_service;
-		$store_integration_service    = $this->store_integration_service;
-		$store_integration_repository = $this->store_integration_repository;
+		$connection_service        = $this->connection_service;
+		$store_integration_service = $this->store_integration_service;
+		$store_integrations_proxy  = $this->store_integrations_proxy;
 
 		ServiceRegister::registerService(
 			ConnectionService::class,
@@ -101,17 +102,16 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 			}
 		);
 		ServiceRegister::registerService(
-			StoreIntegrationRepositoryInterface::class,
-			static function () use ( $store_integration_repository ) {
-				return $store_integration_repository;
+			StoreIntegrationsProxyInterface::class,
+			static function () use ( $store_integrations_proxy ) {
+				return $store_integrations_proxy;
 			}
 		);
 
 		$this->migration = new Migration_Install_430(
 			$this->wpdb,
 			new Cache_Repository(),
-			$this->store_service,
-			$this->logger
+			$this->store_service
 		);
 	}
 
@@ -127,24 +127,11 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 		$this->migration->run();
 	}
 
-	public function testRun_withExistingStoreIntegration_skipsCreateStoreIntegration(): void {
+	public function testRun_callsCreateStoreIntegrationForEachConnection(): void {
 		$connection_data = $this->createMock( ConnectionData::class );
 
 		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
 		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
-		$this->store_integration_repository->method( 'getStoreIntegration' )
-			->willReturn( $this->createMock( StoreIntegration::class ) );
-		$this->store_integration_service->expects( $this->never() )->method( 'createStoreIntegration' );
-
-		$this->migration->run();
-	}
-
-	public function testRun_withNoStoreIntegration_callsCreateStoreIntegrationWithConnectionData(): void {
-		$connection_data = $this->createMock( ConnectionData::class );
-
-		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
-		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
-		$this->store_integration_repository->method( 'getStoreIntegration' )->willReturn( null );
 		$this->store_integration_service->expects( $this->once() )
 			->method( 'createStoreIntegration' )
 			->with( $connection_data );
@@ -159,7 +146,6 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
 		$this->connection_service->method( 'getAllConnectionData' )
 			->willReturn( array( $connection_data_1, $connection_data_2 ) );
-		$this->store_integration_repository->method( 'getStoreIntegration' )->willReturn( null );
 		$this->store_integration_service->expects( $this->exactly( 2 ) )
 			->method( 'createStoreIntegration' )
 			->willReturnCallback(
@@ -179,11 +165,108 @@ class MigrationInstall430Test extends WP_UnitTestCase {
 
 		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1', 'store2' ) );
 		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
-		$this->store_integration_repository->method( 'getStoreIntegration' )->willReturn( null );
 		$this->store_integration_service->expects( $this->exactly( 2 ) )
 			->method( 'createStoreIntegration' );
 
 		$this->migration->run();
 		$this->assertTrue( true );
+	}
+
+	public function testRun_withOldStoreIntegrationInDb_callsDeleteStoreIntegrationWithOldUrl(): void {
+		$old_webhook_url = 'https://example.com/webhook?storeId=store1&signature=old_random_sig';
+		$this->insert_store_integration_entity( 'store1', $old_webhook_url );
+
+		$connection_data = $this->createMock( ConnectionData::class );
+		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
+		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
+
+		$this->store_integrations_proxy->expects( $this->once() )
+			->method( 'deleteStoreIntegration' )
+			->with(
+				$this->callback(
+					function ( DeleteStoreIntegrationRequest $request ) use ( $old_webhook_url ) {
+						return $request->getWebhookUrl() === $old_webhook_url;
+					}
+				)
+			);
+
+		$this->migration->run();
+	}
+
+	public function testRun_withNoOldStoreIntegrationInDb_doesNotCallDeleteStoreIntegration(): void {
+		$connection_data = $this->createMock( ConnectionData::class );
+		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
+		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
+
+		$this->store_integrations_proxy->expects( $this->never() )->method( 'deleteStoreIntegration' );
+
+		$this->migration->run();
+	}
+
+	public function testRun_withSuccessfulRegistration_deletesOldStoreIntegrationEntityFromDb(): void {
+		$this->insert_store_integration_entity( 'store1', 'https://example.com/webhook?storeId=store1&signature=old' );
+
+		$connection_data = $this->createMock( ConnectionData::class );
+		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
+		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
+
+		$this->migration->run();
+
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT COUNT(*) FROM {$this->entity_table} WHERE type = %s AND index_1 = %s",
+				'StoreIntegration',
+				'store1'
+			)
+		);
+		$this->assertSame( '0', $count );
+	}
+
+	public function testRun_withFailingRegistration_doesNotDeleteOldDbRow(): void {
+		$this->insert_store_integration_entity( 'store1', 'https://example.com/webhook?storeId=store1&signature=old' );
+
+		$connection_data = $this->createMock( ConnectionData::class );
+		$this->store_service->method( 'getConnectedStores' )->willReturn( array( 'store1' ) );
+		$this->connection_service->method( 'getAllConnectionData' )->willReturn( array( $connection_data ) );
+		$this->store_integration_service->method( 'createStoreIntegration' )
+			->willThrowException( new RuntimeException( 'API error' ) );
+
+		try {
+			$this->migration->run();
+		} catch ( Exception $e ) {
+			// Expected.
+		}
+
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT COUNT(*) FROM {$this->entity_table} WHERE type = %s AND index_1 = %s",
+				'StoreIntegration',
+				'store1'
+			)
+		);
+		$this->assertSame( '1', $count );
+	}
+
+	/**
+	 * Insert a StoreIntegration entity row into the DB.
+	 *
+	 * @param string $store_id    Store identifier (index_1).
+	 * @param string $webhook_url Old webhook URL stored in the entity data.
+	 */
+	private function insert_store_integration_entity( string $store_id, string $webhook_url ): void {
+		$this->wpdb->insert(
+			$this->entity_table,
+			array(
+				'type'    => 'StoreIntegration',
+				'index_1' => $store_id,
+				'data'    => wp_json_encode(
+					array(
+						'storeIntegration' => array(
+							'webhookUrl' => $webhook_url,
+						),
+					)
+				),
+			)
+		);
 	}
 }


### PR DESCRIPTION
### What is the goal?

Update the `sequra/integration-core` dependency to `dev-refactor/PAR-772-StoreIntegration-Signature-Redesign` and adapt all WooCommerce plugin code that references the removed classes (`StoreIntegration` entity, `StoreIntegrationRepository`, `StoreIntegrationRepositoryInterface`, `StoreIntegration` domain model). Update the v4.3.0 migration to reflect the new HMAC-based signature approach, and update Bootstrap service registrations accordingly.

### References

- **Issue:** [PAR-773](https://sequra.atlassian.net/browse/PAR-773)
- **Related pull-requests:** depends on PAR-772 (`refactor/PAR-772-StoreIntegration-Signature-Redesign` in integration-core)

### Definition of done

- [x] `composer.json` references the new integration-core branch with `minimum-stability: dev`
- [x] No references to removed classes remain in plugin source
- [x] Bootstrap no longer registers `StoreIntegration` entity in `RepositoryRegistry`
- [x] The v4.3.0 migration creates store integrations without checking the repository, deregisters old integrations via API before registering new ones, and cleans up old DB rows on success
- [x] PHPStan level 9 passes
- [x] PHPCS passes
- [x] Unit tests pass (177/177)

### How is it being implemented?

- **Step 1:** Updated `composer.json` — added `minimum-stability: dev`, changed integration-core version to `dev-refactor/PAR-772-StoreIntegration-Signature-Redesign`, ran `composer update`.
- **Step 2:** Removed `StoreIntegration` entity `use` import and `RepositoryRegistry::registerRepository()` call from `class-bootstrap.php`.
- **Step 3:** Rewrote `Migration_Install_430` — removed `StoreIntegrationRepositoryInterface` dependency; added `get_old_webhook_url()` to read the stored random-signature webhook URL from the DB; for each connection calls `proxy->deleteStoreIntegration()` (best-effort) with the old URL before calling `createStoreIntegration()`; deletes the old DB row per store after all connections succeed.
- **Step 4:** Updated `MigrationInstall430Test` — replaced repository mocks with proxy mock, added DB-level tests for cleanup and deregistration behaviour.

### Caveats

- `minimum-stability: dev` is temporary — must be reverted to a release tag before merging to production. `prefer-stable: true` already present to mitigate pulling unstable transitive deps.
- Stores upgrading from the old random-signature approach will have their webhook URL re-registered with the seQura API during the migration. If the API call fails, the old DB row is preserved and the migration retries on next plugin load.

### How is it tested?

Unit tests cover: no-store no-op, create called per connection, failure loop continues and throws, proxy called with old webhook URL, proxy not called when no old row exists, DB row deleted on success, DB row preserved on failure.

PHPStan (level 9) and PHPCS pass. E2E tests (configuration-onboarding, checkout) should be run manually once integration-core PAR-772 is finalised and a release tag is available.

#### Manual tests:
- [x] Disable plugin version 4.3.0
- [x] Remove sequra tables in database.
- [x] Manually remove the existing StoreIntegrations from the API.
- [x] Install plugin version 4.2.0.
- [x] Configure the plugin so it generates the same StoreIntegration as before.
- [x] Verify that the StoreIntegration exists in the database and the API.
- [x] Deactivate version 4.2.0 and activate version 4.3.0.
- [x] Verify that the old StoreIntegration is removed from the database and the API.
- [x] Verify that the new StoreIntegration is created in the API.
- [x] The webhook URL in the new StoreIntegration responds with a 200 status code to a POST request.
- [x] Test that recreating the StoreIntegration in version 4.3.0 after reconnecting is idempotent and does not create duplicate StoreIntegrations in the API.
- [x] Upgrade from 4.2.0 to 4.3.0 without an existing StoreIntegration and verify that the new StoreIntegration is created in the API.

### How is it going to be deployed?

Standard deployment. The migration runs automatically on plugin update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAR-773]: https://sequra.atlassian.net/browse/PAR-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ