### PR TITLE
[PAR-763] Remove stale connection data on 401 error response

### DIFF
--- a/sequra/src/Repositories/Migrations/class-migration-install-430.php
+++ b/sequra/src/Repositories/Migrations/class-migration-install-430.php
@@ -9,7 +9,10 @@
 namespace SeQura\WC\Repositories\Migrations;
 
 use Exception;
+use SeQura\Core\BusinessLogic\Domain\Connection\RepositoryContracts\ConnectionDataRepositoryInterface;
+use SeQura\Core\BusinessLogic\Domain\Connection\RepositoryContracts\CredentialsRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\Connection\Services\ConnectionService;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\RepositoryContracts\PaymentMethodRepositoryInterface;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
 use SeQura\Core\BusinessLogic\Domain\StoreIntegration\Models\DeleteStoreIntegrationRequest;
 use SeQura\Core\BusinessLogic\Domain\StoreIntegration\ProxyContracts\StoreIntegrationsProxyInterface;
@@ -90,6 +93,9 @@ class Migration_Install_430 extends Migration {
 							$this->get_store_integration_service()->createStoreIntegration( $connection_data );
 						} catch ( Throwable $e ) {
 							$this->try_log( $e );
+							if ( 401 === $e->getCode() ) {
+								$this->remove_stale_deployment_data( $connection_data );
+							}
 						}
 					}
 
@@ -186,6 +192,64 @@ class Migration_Install_430 extends Migration {
 		 */
 		$service = ServiceRegister::getService( StoreIntegrationService::class );
 		return $service;
+	}
+
+	/**
+	 * Remove the connection data, credentials and payment methods from the database for a given deployment.
+	 *
+	 * @param \SeQura\Core\BusinessLogic\Domain\Connection\Models\ConnectionData $connection_data
+	 */
+	private function remove_stale_deployment_data( $connection_data ): void {
+		try {
+			$deployment_id = $connection_data->getDeployment();
+			$merchant_ids  = $this->get_credentials_repository()->deleteCredentialsByDeploymentId( $deployment_id );
+			foreach ( $merchant_ids as $merchant_id ) {
+				$this->get_payment_method_repository()->deletePaymentMethods( $merchant_id );
+			}
+				
+			$this->get_connection_data_repository()->deleteConnectionDataByDeploymentId( $deployment_id );
+		} catch ( Throwable $e ) {
+			$this->try_log( $e );
+		}
+	}
+
+	/**
+	 * Get connection data repository instance.
+	 */
+	private function get_connection_data_repository(): ConnectionDataRepositoryInterface {
+		/**
+		 * Connection data repository.
+		 *
+		 * @var ConnectionDataRepositoryInterface $repository
+		 */
+		$repository = ServiceRegister::getService( ConnectionDataRepositoryInterface::class );
+		return $repository;
+	}
+
+	/**
+	 * Get credentials repository instance.
+	 */
+	private function get_credentials_repository(): CredentialsRepositoryInterface {
+		/**
+		 * Credentials repository.
+		 *
+		 * @var CredentialsRepositoryInterface $repository
+		 */
+		$repository = ServiceRegister::getService( CredentialsRepositoryInterface::class );
+		return $repository;
+	}
+
+	/**
+	 * Get payment method repository instance.
+	 */
+	private function get_payment_method_repository(): PaymentMethodRepositoryInterface {
+		/**
+		 * Payment method repository.
+		 *
+		 * @var PaymentMethodRepositoryInterface $repository
+		 */
+		$repository = ServiceRegister::getService( PaymentMethodRepositoryInterface::class );
+		return $repository;
 	}
 
 	/**


### PR DESCRIPTION
### What is the goal?

Remove stale connection data on 401 error response

### References

- **Issue:** PAR-763

### How is it being implemented?

This pull request enhances the migration process in `class-migration-install-430.php` by improving the handling of failed store integration attempts, specifically for authentication errors. When a 401 error occurs, the code now removes stale deployment data to maintain data consistency. Several new helper methods and repository dependencies have been introduced to support this cleanup.

**Error handling and data cleanup:**

* On catching a 401 error during store integration creation, the code now invokes a new method to remove stale deployment data, ensuring that invalid or outdated records are cleaned up.
* Added the `remove_stale_deployment_data` method, which deletes connection data, credentials, and payment methods associated with the failed deployment.

**Repository access improvements:**

* Introduced new helper methods: `get_connection_data_repository`, `get_credentials_repository`, and `get_payment_method_repository` to retrieve the necessary repository instances for data cleanup.
* Added required repository interface imports to support the new methods and data removal logic.

### How is it tested?

Manual tests

### How is it going to be deployed?

Standard deployment
