### PR TITLE
Fix 500 Error On Empty Webhook Body

### DIFF
--- a/sequra/src/Controllers/Rest/class-store-integration-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-store-integration-rest-controller.php
@@ -85,7 +85,7 @@ class Store_Integration_REST_Controller extends REST_Controller {
 
 	/**
 	 * Handle POST request.
-	 * 
+	 *
 	 * @throws \Exception
 	 * @param WP_REST_Request $request The request.
 	 *
@@ -94,8 +94,20 @@ class Store_Integration_REST_Controller extends REST_Controller {
 	public function handle_post( WP_REST_Request $request ) {
 		$signature = $request->get_param( 'signature' );
 		$payload   = $request->get_json_params();
-		$response  = ConfigurationWebhookAPI::configurationHandler( $this->store_context->getStoreId() )
+		if ( ! is_array( $payload ) ) {
+			$payload = array();
+		}
+		$response    = ConfigurationWebhookAPI::configurationHandler( $this->store_context->getStoreId() )
 		->handleRequest( $signature, $payload );
-		return $this->build_response( $response );
+		$wp_response = $this->build_response( $response );
+
+		if ( $wp_response instanceof WP_Error ) {
+			$response_array = $response->toArray();
+			if ( isset( $response_array['errorCode'] ) && 'TOPIC_MISSING' === $response_array['errorCode'] ) {
+				$wp_response->add_data( array( 'status' => 400 ) );
+			}
+		}
+
+		return $wp_response;
 	}
 }

--- a/sequra/src/Controllers/Rest/class-store-integration-rest-controller.php
+++ b/sequra/src/Controllers/Rest/class-store-integration-rest-controller.php
@@ -9,6 +9,7 @@
 namespace SeQura\WC\Controllers\Rest;
 
 use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\ConfigurationWebhookAPI;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\TopicMissingErrorResponse;
 use SeQura\WC\Services\Log\Interface_Logger_Service;
 use SeQura\Core\Infrastructure\Utility\RegexProvider;
 use SeQura\WC\Core\Implementation\BusinessLogic\Domain\Integration\StoreIntegration\Interface_Store_Integration_Service;
@@ -94,18 +95,15 @@ class Store_Integration_REST_Controller extends REST_Controller {
 	public function handle_post( WP_REST_Request $request ) {
 		$signature = $request->get_param( 'signature' );
 		$payload   = $request->get_json_params();
-		if ( ! is_array( $payload ) ) {
+		if ( ! \is_array( $payload ) ) {
 			$payload = array();
 		}
 		$response    = ConfigurationWebhookAPI::configurationHandler( $this->store_context->getStoreId() )
 		->handleRequest( $signature, $payload );
 		$wp_response = $this->build_response( $response );
 
-		if ( $wp_response instanceof WP_Error ) {
-			$response_array = $response->toArray();
-			if ( isset( $response_array['errorCode'] ) && 'TOPIC_MISSING' === $response_array['errorCode'] ) {
-				$wp_response->add_data( array( 'status' => 400 ) );
-			}
+		if ( $wp_response instanceof WP_Error && $response instanceof TopicMissingErrorResponse ) {
+			$wp_response->add_data( array( 'status' => 400 ) );
 		}
 
 		return $wp_response;

--- a/sequra/tests/Controllers/Rest/StoreIntegrationRestControllerTest.php
+++ b/sequra/tests/Controllers/Rest/StoreIntegrationRestControllerTest.php
@@ -97,16 +97,22 @@ class StoreIntegrationRestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'sequra/v1', $namespace );
 	}
 
-	public function testHandlePost_nullPayload_coercesToEmptyArrayAndMapsTopicMissingTo400(): void {
+	/**
+	 * @dataProvider topicMissingPayloadProvider
+	 *
+	 * @param mixed   $json_params          Value get_json_params() should return.
+	 * @param mixed[] $expected_handler_arg Payload the handler should be invoked with after coercion.
+	 */
+	public function testHandlePost_topicMissingResponse_mapsToHttp400( $json_params, array $expected_handler_arg ): void {
 		$webhook_controller = $this->register_webhook_controller_mock();
 		$webhook_controller->expects( $this->once() )
 			->method( 'handleRequest' )
-			->with( 'sig', array() )
+			->with( 'sig', $expected_handler_arg )
 			->willReturn( new TopicMissingErrorResponse() );
 
 		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
 
-		$request = $this->build_request( null, 'sig' );
+		$request = $this->build_request( $json_params, 'sig' );
 
 		$result = $this->controller->handle_post( $request );
 
@@ -114,38 +120,15 @@ class StoreIntegrationRestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'status' => 400 ), $result->get_error_data() );
 	}
 
-	public function testHandlePost_nonArrayJsonPayload_coercesToEmptyArrayAndMapsTopicMissingTo400(): void {
-		$webhook_controller = $this->register_webhook_controller_mock();
-		$webhook_controller->expects( $this->once() )
-			->method( 'handleRequest' )
-			->with( 'sig', array() )
-			->willReturn( new TopicMissingErrorResponse() );
-
-		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
-
-		$request = $this->build_request( 42, 'sig' );
-
-		$result = $this->controller->handle_post( $request );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( array( 'status' => 400 ), $result->get_error_data() );
-	}
-
-	public function testHandlePost_payloadWithoutTopic_returnsTopicMissingMappedTo400(): void {
-		$webhook_controller = $this->register_webhook_controller_mock();
-		$webhook_controller->expects( $this->once() )
-			->method( 'handleRequest' )
-			->with( 'sig', array( 'foo' => 'bar' ) )
-			->willReturn( new TopicMissingErrorResponse() );
-
-		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
-
-		$request = $this->build_request( array( 'foo' => 'bar' ), 'sig' );
-
-		$result = $this->controller->handle_post( $request );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( array( 'status' => 400 ), $result->get_error_data() );
+	/**
+	 * @return mixed[][]
+	 */
+	public function topicMissingPayloadProvider(): array {
+		return array(
+			'null payload coerces to empty array'        => array( null, array() ),
+			'non-array payload coerces to empty array'   => array( 42, array() ),
+			'array payload without topic passes through' => array( array( 'foo' => 'bar' ), array( 'foo' => 'bar' ) ),
+		);
 	}
 
 	public function testHandlePost_validPayload_returnsSuccessResponse(): void {
@@ -178,7 +161,7 @@ class StoreIntegrationRestControllerTest extends WP_UnitTestCase {
 		$result = $this->controller->handle_post( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertNotSame( array( 'status' => 400 ), $result->get_error_data() );
+		$this->assertNull( $result->get_error_data() );
 	}
 
 	/**

--- a/sequra/tests/Controllers/Rest/StoreIntegrationRestControllerTest.php
+++ b/sequra/tests/Controllers/Rest/StoreIntegrationRestControllerTest.php
@@ -8,11 +8,20 @@
 
 namespace SeQura\WC\Tests\Controllers\Rest;
 
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Controller\ConfigurationWebhookController;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\SuccessResponse;
+use SeQura\Core\BusinessLogic\ConfigurationWebhookAPI\Responses\TopicMissingErrorResponse;
 use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
+use SeQura\Core\BusinessLogic\Domain\Translations\Model\TranslatableLabel;
+use SeQura\Core\BusinessLogic\Domain\Webhook\Exceptions\WebhookSignatureValidationFailed;
+use SeQura\Core\Infrastructure\ServiceRegister;
 use SeQura\Core\Infrastructure\Utility\RegexProvider;
 use SeQura\WC\Controllers\Rest\Store_Integration_REST_Controller;
 use SeQura\WC\Core\Implementation\BusinessLogic\Domain\Integration\StoreIntegration\Interface_Store_Integration_Service;
 use SeQura\WC\Services\Log\Interface_Logger_Service;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_UnitTestCase;
 
 class StoreIntegrationRestControllerTest extends WP_UnitTestCase {
@@ -86,5 +95,129 @@ class StoreIntegrationRestControllerTest extends WP_UnitTestCase {
 		$namespace = $reflection->getValue( $this->controller );
 
 		$this->assertSame( 'sequra/v1', $namespace );
+	}
+
+	public function testHandlePost_nullPayload_coercesToEmptyArrayAndMapsTopicMissingTo400(): void {
+		$webhook_controller = $this->register_webhook_controller_mock();
+		$webhook_controller->expects( $this->once() )
+			->method( 'handleRequest' )
+			->with( 'sig', array() )
+			->willReturn( new TopicMissingErrorResponse() );
+
+		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
+
+		$request = $this->build_request( null, 'sig' );
+
+		$result = $this->controller->handle_post( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array( 'status' => 400 ), $result->get_error_data() );
+	}
+
+	public function testHandlePost_nonArrayJsonPayload_coercesToEmptyArrayAndMapsTopicMissingTo400(): void {
+		$webhook_controller = $this->register_webhook_controller_mock();
+		$webhook_controller->expects( $this->once() )
+			->method( 'handleRequest' )
+			->with( 'sig', array() )
+			->willReturn( new TopicMissingErrorResponse() );
+
+		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
+
+		$request = $this->build_request( 42, 'sig' );
+
+		$result = $this->controller->handle_post( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array( 'status' => 400 ), $result->get_error_data() );
+	}
+
+	public function testHandlePost_payloadWithoutTopic_returnsTopicMissingMappedTo400(): void {
+		$webhook_controller = $this->register_webhook_controller_mock();
+		$webhook_controller->expects( $this->once() )
+			->method( 'handleRequest' )
+			->with( 'sig', array( 'foo' => 'bar' ) )
+			->willReturn( new TopicMissingErrorResponse() );
+
+		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
+
+		$request = $this->build_request( array( 'foo' => 'bar' ), 'sig' );
+
+		$result = $this->controller->handle_post( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array( 'status' => 400 ), $result->get_error_data() );
+	}
+
+	public function testHandlePost_validPayload_returnsSuccessResponse(): void {
+		$webhook_controller = $this->register_webhook_controller_mock();
+		$webhook_controller->method( 'handleRequest' )->willReturn( new SuccessResponse() );
+
+		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
+
+		$request = $this->build_request( array( 'topic' => 'order.created' ), 'sig' );
+
+		$result = $this->controller->handle_post( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+	}
+
+	public function testHandlePost_signatureFailure_doesNotApply400Mapping(): void {
+		$webhook_controller = $this->register_webhook_controller_mock();
+		$webhook_controller->method( 'handleRequest' )
+			->willThrowException(
+				new WebhookSignatureValidationFailed(
+					new TranslatableLabel( 'Webhook signature validation failed.', 'webhook.signature.validation.failed' )
+				)
+			);
+
+		$this->store_context->method( 'getStoreId' )->willReturn( '1' );
+
+		$request = $this->build_request( null, 'bad-sig' );
+
+		$result = $this->controller->handle_post( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertNotSame( array( 'status' => 400 ), $result->get_error_data() );
+	}
+
+	/**
+	 * Replace the bootstrapped ConfigurationWebhookController with a mock so the Aspects proxy
+	 * resolves to it. Returns the mock so individual tests can configure expectations.
+	 *
+	 * @return ConfigurationWebhookController&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function register_webhook_controller_mock() {
+		$mock = $this->getMockBuilder( ConfigurationWebhookController::class )
+			->disableOriginalConstructor()
+			->getMock();
+		ServiceRegister::registerService(
+			ConfigurationWebhookController::class,
+			static function () use ( $mock ) {
+				return $mock;
+			}
+		);
+		return $mock;
+	}
+
+	/**
+	 * Build a WP_REST_Request mock that returns the given JSON payload and signature.
+	 *
+	 * @param mixed $json_params Value returned from get_json_params().
+	 * @param string $signature Value returned from get_param('signature').
+	 *
+	 * @return WP_REST_Request&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function build_request( $json_params, string $signature ) {
+		$request = $this->getMockBuilder( WP_REST_Request::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$request->method( 'get_param' )->willReturnCallback(
+			static function ( $key ) use ( $signature ) {
+				return 'signature' === $key ? $signature : null;
+			}
+		);
+		$request->method( 'get_json_params' )->willReturn( $json_params );
+		return $request;
 	}
 }


### PR DESCRIPTION
### What is the goal?

Stop the webhook endpoint from 500-ing on empty / non-array bodies. The plugin will coerce `null` payloads to `[]` before calling the core handler so signature validation can run and the core can return its proper `TopicMissingErrorResponse`. The plugin will also map the `TOPIC_MISSING` error to HTTP 400 on the way out, so missing/invalid bodies surface as a client error rather than a server error.

### References

- **Issue:** PAR-781

### Definition of done

- [x] `curl -X POST "<webhook-url>"` with valid signature returns HTTP 400 (not 500).
- [x] `curl -X POST "<webhook-url>" -d '{"topic":"unknown"}'` with valid signature still returns the unknown-topic response (regression check).
- [x] Unit test for `Store_Integration_REST_Controller::handle_post` covers: null payload, non-array JSON, topic-missing payload (→ 400), and a successful payload (→ existing pass-through).
- [x] `./bin/phpcs`, `./bin/phpstan`, and the phpunit suite pass.

### How is it being implemented?

**Root cause.** `WP_REST_Request::get_json_params()` returns `null` for an empty body. The plugin forwarded that `null` to `ConfigurationWebhookController::handleRequest(string $signature, array $payload)` in `sequra/integration-core`, which has a non-nullable `array` type-hint. PHP threw a `TypeError`, `ErrorHandlingAspect` caught it as `BaseTranslatableUnhandledException`, and the resulting `WP_Error` had no `status` data — WordPress fell back to HTTP 500. A secondary defect: even with a coerced `[]` payload, `TopicMissingErrorResponse` has no `statusCode`, so the plugin's `build_response_from_array` fallback also yielded 500.

**Fix.** Plugin-only, no `integration-core` change:

1. In `Store_Integration_REST_Controller::handle_post`, normalize a non-array `get_json_params()` result to `[]` before invoking `handleRequest`. Signature validation now runs as designed; an empty/invalid body produces a proper `TopicMissingErrorResponse` instead of a `TypeError`.
2. After `build_response`, if the resulting `WP_Error` came from a `TopicMissingErrorResponse` (`$response instanceof TopicMissingErrorResponse`), attach `['status' => 400]` so WordPress emits HTTP 400.
3. Added unit tests covering null body, non-array body, missing-topic, valid topic, and signature-failure precedence — driven by a `@dataProvider` for the topic-missing rows.

Cross-checked against `magento2-core/Controller/IntegrationWebhook/Index.php` and the simba proxy (`MerchantPortal::WebhookProxyController` + `ProxyWebhookRequestOperation`); simba is a transparent proxy that forwards the plugin's status verbatim with no code-specific branching, so 400 vs 410 is a presentation-layer choice. 400 is the more correct REST semantic for "topic missing".

### Opportunistic refactorings

A simplify pass replaced an array-shape sniff (`$response->toArray()['errorCode'] === 'TOPIC_MISSING'`) with `$response instanceof TopicMissingErrorResponse`, removing both the magic string and a duplicate `toArray()` call. Three near-duplicate test methods collapsed into one `@dataProvider`-driven test, and the signature-failure test's negative `assertNotSame` was tightened into a positive `assertNull($result->get_error_data())`.

### How is it tested?

- New unit tests in `sequra/tests/Controllers/Rest/StoreIntegrationRestControllerTest.php`:
  - `testHandlePost_topicMissingResponse_mapsToHttp400` (3 data rows: null, scalar `42`, array without `topic`).
  - `testHandlePost_validPayload_returnsSuccessResponse`.
  - `testHandlePost_signatureFailure_doesNotApply400Mapping`.
- Tests register a mocked `ConfigurationWebhookController` via `ServiceRegister` so the Aspects proxy resolves to the mock; `WP_REST_Request` is also mocked.
- Full QA pipeline run locally: `./bin/phpcs` clean (155 + 19 files), `./bin/phpstan` clean at level 9 (both plugins), full phpunit suite 182 tests / 831 assertions all green.

### How is it going to be deployed?

Standard deployment.

## Commits

- 55531d39 PAR-781: simplify - use instanceof check and dataProvider for tests
- 70fca2a0 PAR-781: step 2 - add unit tests for empty/missing-topic/valid/signature-failure paths
- 2f40dab3 PAR-781: step 1 - coerce empty webhook payload and map TOPIC_MISSING to 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)