### PR TITLE
[PAR-706] Upload Web Server Logs and Database Dump on Test Failure

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -306,6 +306,23 @@ jobs:
           path: /tmp/test-results
           retention-days: 7
 
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          mkdir -p /tmp/diagnostics
+          docker compose logs --no-color web > /tmp/diagnostics/web.log 2>&1 || true
+          docker compose logs --no-color db > /tmp/diagnostics/db.log 2>&1 || true
+          docker compose exec -T -u www-data web wp db export - > /tmp/diagnostics/db-dump.sql || true
+
+      - name: Upload diagnostics
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: diagnostics-${{ matrix.suite }}
+          path: /tmp/diagnostics
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Cleanup
         if: always()
         run: ./teardown.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -202,6 +202,14 @@ jobs:
           path: /tmp/test-results
           retention-days: 7
 
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          mkdir -p /tmp/diagnostics
+          docker compose logs --no-color web > /tmp/diagnostics/web.log 2>&1 || true
+          docker compose logs --no-color db > /tmp/diagnostics/db.log 2>&1 || true
+          docker compose exec -T -u www-data web wp db export - > /tmp/diagnostics/db-dump.sql || true
+
       - name: Cleanup
         if: always()
         run: ./teardown.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -210,6 +210,15 @@ jobs:
           docker compose logs --no-color db > /tmp/diagnostics/db.log 2>&1 || true
           docker compose exec -T -u www-data web wp db export - > /tmp/diagnostics/db-dump.sql || true
 
+      - name: Upload diagnostics
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: diagnostics-${{ matrix.suite }}
+          path: /tmp/diagnostics
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Cleanup
         if: always()
         run: ./teardown.sh


### PR DESCRIPTION
### What is the goal?

When the E2E test job fails in CI, additionally capture and upload the web server container logs and a dump of the WordPress database as workflow artifacts, so rare failures can be diagnosed post-mortem.

### References

- **Issue:** https://sequra.atlassian.net/browse/PAR-706

### Definition of done

1. [ ] A failed E2E CI run exposes downloadable artifacts containing the web server logs and a database dump.
1. [ ] A successful E2E CI run does not upload these extra artifacts.
1. [ ] Capture/upload steps never change the job's pass/fail outcome.

### How is it being implemented?

**Affected files**

- `.github/workflows/e2e-tests.yml` — two new steps (`Collect diagnostics`, `Upload diagnostics`) added to both jobs: `e2e-tests-with-tunnel` (suites 001–003) and `e2e-tests-local` (suites 004–006). No PHP/JS source changes.

**Decisions**

- `wp db export -` (stdout) inside the `web` container instead of `mariadb-dump` in `db` — credentials come from wp-config, no secret plumbing in the workflow.
- Single `diagnostics-${{ matrix.suite }}` artifact per failing job for easy run↔artifact matching.
- Steps inlined in both jobs, consistent with how cache/setup steps are already written in this workflow.

**Steps**

1. In job `e2e-tests-with-tunnel`, add a `Collect diagnostics` step (`if: failure()`) after `Upload test results` and before `Cleanup`: create `/tmp/diagnostics`, write `docker compose logs --no-color web`, `docker compose logs --no-color db`, and `docker compose exec -T -u www-data web wp db export -` into it, each guarded with `|| true`.
2. Same job: add an `Upload diagnostics` step (`if: failure()`, `actions/upload-artifact@v6`, name `diagnostics-${{ matrix.suite }}`, path `/tmp/diagnostics`, `retention-days: 7`, `if-no-files-found: ignore`).
3. Replicate both steps in the `e2e-tests-local` job, before its `Cleanup` step.
4. Validate the workflow YAML and run the QA pipeline (`./bin/phpcs`, `./bin/phpstan`).

### Caveats

- Capture commands are best-effort (`|| true`): a broken web container (the very thing being diagnosed) never fails the capture step or changes the job outcome.
- If WordPress is too broken for wp-cli, the dump is empty — container logs still upload.
- Capture runs before `Cleanup` (`teardown.sh`), which removes containers and volumes; step ordering in the YAML guarantees this.

### How is it tested?

- Workflow YAML validated; `./bin/phpcs` and `./bin/phpstan` pass.
- Manual verification: trigger a deliberately failing E2E run and check the `diagnostics-<suite>` artifacts appear and are readable; verify a passing run uploads no extra artifacts.

### How is it going to be deployed?

Standard deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)