### PR TITLE
[PAR-805] Add Claude configuration and capability definitions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,14 +16,13 @@
       "Bash(git show:*)",
       "Bash(git branch:*)",
       "Bash(git --version)",
-      "Bash(git check-attr *)",
       "Skill(sq-git:commit)",
       "Skill(sq-git:open-pr)",
       "Skill(sq-git:sync-branch)"
     ],
     "deny": [
       "Read(.env)",
-      "Read(.env.*)",
+      "Read(.env.local)",
       "Read(**/*.pem)",
       "Read(**/*.key)"
     ],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bin/phpcs:*)",
+      "Bash(bin/phpcbf:*)",
+      "Bash(bin/phpstan:*)",
+      "Bash(bin/php-syntax-check:*)",
+      "Bash(bin/composer:*)",
+      "Bash(bin/npm:*)",
+      "Bash(bin/playwright:*)",
+      "Bash(php -l:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git --version)",
+      "Bash(git check-attr *)",
+      "Skill(sq-git:commit)",
+      "Skill(sq-git:open-pr)",
+      "Skill(sq-git:sync-branch)"
+    ],
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)"
+    ],
+    "ask": [
+      "Bash(./setup.sh:*)",
+      "Bash(./teardown.sh:*)",
+      "Bash(git push:*)"
+    ]
+  }
+}

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: version-bump
+description: Bump the seQura WooCommerce plugin version across the two coupled locations (sequra/sequra.php header and sequra/readme.txt stable tag + changelog), keeping them in sync and writing the changelog entry. Use when releasing a new plugin version.
+---
+
+# Version bump (seQura Payment Gateway for WooCommerce)
+
+The plugin version lives in **two files that must stay in sync**. Bumping one
+without the other ships a broken release: WordPress reads the `Version:` header
+to detect updates, and the `Stable tag:` in `readme.txt` is what wordpress.org
+serves. Always change both, plus add a changelog entry.
+
+## The two coupled locations
+
+1. **`sequra/sequra.php`** — the plugin header:
+   ```php
+    * Version:           4.3.2
+   ```
+2. **`sequra/readme.txt`** — the WordPress.org readme:
+   - The stable tag near the top:
+     ```
+     Stable tag: 4.3.2
+     ```
+   - A new entry under `== Changelog ==` (entries are newest-first):
+     ```
+     = 4.3.3	=
+     * Fixed: <what changed>.
+     * Changed: <what changed>.
+     ```
+     Note: the existing entries use a literal TAB between the version and the
+     trailing `=` (`= 4.3.2\t=`). Match that exact format.
+
+There is **no** PHP version constant — these two files are the only sources of
+truth. Do not invent a `SEQURA_VERSION` define.
+
+## Procedure
+
+Given a target version `X.Y.Z`:
+
+1. **Confirm the current version and the target.** Read the current value from
+   `sequra/sequra.php` (`Version:`) and `sequra/readme.txt` (`Stable tag:`) and
+   make sure they already agree. If they don't, surface the mismatch before
+   touching anything — that's an existing bug, not something to silently paper
+   over.
+
+2. **Decide the bump** (semver): patch for fixes, minor for backwards-compatible
+   features, major for breaking changes. If the user didn't specify, ask.
+
+3. **Edit `sequra/sequra.php`** — update the `Version:` header to `X.Y.Z`.
+
+4. **Edit `sequra/readme.txt`**:
+   - Update `Stable tag:` to `X.Y.Z`.
+   - Insert a new `= X.Y.Z\t=` block at the **top** of the `== Changelog ==`
+     section (above the previous newest entry). Summarise the changes since the
+     last release as `* Fixed:` / `* Changed:` / `* Added:` bullets. If an
+     `integration-core` upgrade is part of the release, include a
+     `* Changed: Update integration-core library to version vA.B.C.` line, as
+     prior entries do.
+   - If WordPress / WooCommerce "Tested up to" versions changed this release,
+     also update `Tested up to:` near the top and mention it in the changelog.
+
+5. **Verify the two files agree.** Re-read both; the version string must be
+   byte-identical in `sequra.php` (`Version:`) and `readme.txt` (`Stable tag:`),
+   and the new changelog block's version must match too.
+
+6. **Sanity-check the build** doesn't break: `bin/make_zip` reads the version
+   from the `sequra.php` `Version:` header (`grep "Version:" sequra.php`) to
+   name the artifact, so the header format must stay `Version:           X.Y.Z`.
+
+## Tagging / release
+
+Committing and tagging is a separate, deliberate step — do it only when the user
+asks to release:
+
+- Commit the version bump (use the `sq-git:commit` skill).
+- The git tag convention for this repo is the bare version `X.Y.Z` (check
+  `git tag` for the existing pattern before tagging).
+- Publishing to wordpress.org is handled separately by
+  `bin/publish_to_wordpress.sh` — do not run it as part of a routine bump unless
+  explicitly asked.
+
+## Checklist
+
+- [ ] `sequra/sequra.php` `Version:` = `X.Y.Z`
+- [ ] `sequra/readme.txt` `Stable tag:` = `X.Y.Z`
+- [ ] New `= X.Y.Z	=` changelog block added at the top of `== Changelog ==`
+- [ ] `Tested up to:` updated if WP/WC support changed
+- [ ] Both version strings verified identical

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# seQura WooCommerce pre-commit quality gate (operates on staged .php files).
+#
+# Shipped in the repo and enabled by ./setup.sh via:
+#     git config core.hooksPath .githooks
+# Bypass once with:
+#     git commit --no-verify
+#
+# Checks, in order, on the staged .php files:
+#   1. PHP 7.3 syntax (the language floor — sequra/composer.json requires
+#      php 7.3.0, and sequra.php / readme.txt declare "Requires PHP: 7.3").
+#   2. phpcbf then phpcs (WordPress standard, each plugin's .phpcs.xml.dist),
+#      scoped to the staged files; phpcbf's fixes are re-staged so they land in
+#      the commit.
+#   3. PHPStan (level 9), scoped to the staged files PHPStan actually analyses
+#      (src/, templates/, and the plugin entry file — see phpstan.neon `paths:`)
+#      for fast per-commit feedback.
+#
+# All steps run in THROWAWAY Docker images — php:7.3-cli-alpine for the syntax
+# lint, php:8.4-cli-alpine for phpcs/phpcbf/phpstan (the same image the bin/
+# wrappers use) — so this hook does NOT need the dev containers running, only
+# each plugin's vendor/ populated (./setup.sh --install).
+#
+# The heavier gates run in the pre-push hook (.githooks/pre-push), matching CI:
+# the 7.3-8.4 syntax sweep, the FULL phpcs + FULL phpstan over both plugins, and
+# the PHPUnit suite (which needs the web container, so it can't run here).
+# Scoped phpstan here trades some accuracy for speed — phpstan sees only the
+# staged files, so the full pre-push run remains the authority.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Staged PHP files (added/copied/modified), NUL-delimited to tolerate spaces.
+STAGED_PHP=()
+while IFS= read -r -d '' f; do
+    STAGED_PHP+=("$f")
+done < <(git diff --cached --name-only --diff-filter=ACM -z -- '*.php')
+
+if [ ${#STAGED_PHP[@]} -eq 0 ]; then
+    echo "No staged PHP files — skipping PHP checks."
+    exit 0
+fi
+
+UIDGID="$(id -u):$(id -g)"
+
+echo "▶ PHP 7.3 syntax check on ${#STAGED_PHP[@]} staged file(s)..."
+docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:7.3-cli-alpine \
+    sh -c 'rc=0; for f in "$@"; do php -l -n "$f" >/dev/null || rc=1; done; exit $rc' _ "${STAGED_PHP[@]}"
+
+# phpcbf (auto-fix) → phpcs (the authority) → scoped phpstan, per plugin, on the
+# staged files. Each plugin carries its own vendored toolchain, .phpcs.xml.dist
+# and phpstan.neon, so files are mounted/checked from within their plugin root
+# with relative paths.
+run_checks_for_plugin() {
+    local plugin="$1"
+    shift
+    local rel=("$@")
+    [ ${#rel[@]} -eq 0 ] && return 0
+
+    if [ ! -x "$plugin/vendor/bin/phpcs" ] || [ ! -x "$plugin/vendor/bin/phpstan" ]; then
+        echo "✗ $plugin/vendor is not installed — run ./setup.sh --install"
+        echo "  (or bypass this hook once with: git commit --no-verify)"
+        exit 1
+    fi
+
+    echo "▶ PHP Code Beautifier (phpcbf) — $plugin..."
+    # phpcbf exits non-zero when it fixes things; phpcs below is the authority.
+    docker run --rm -v "$PWD/$plugin":/app -w /app -u "$UIDGID" php:8.4-cli-alpine \
+        php vendor/bin/phpcbf --standard=.phpcs.xml.dist "${rel[@]}" || true
+
+    echo "▶ PHP_CodeSniffer (phpcs) — $plugin..."
+    docker run --rm -v "$PWD/$plugin":/app -w /app -u "$UIDGID" php:8.4-cli-alpine \
+        php vendor/bin/phpcs --standard=.phpcs.xml.dist "${rel[@]}"
+
+    # Scoped PHPStan: only the staged files inside the analysed paths (src/,
+    # templates/, the plugin entry file). Passing explicit paths overrides the
+    # neon `paths:` while keeping its level/ignoreErrors.
+    local analyzable=()
+    for f in "${rel[@]}"; do
+        case "$f" in
+            src/*|templates/*|"$plugin".php) analyzable+=("$f") ;;
+        esac
+    done
+    if [ ${#analyzable[@]} -gt 0 ]; then
+        echo "▶ PHPStan (scoped, ${#analyzable[@]} file(s)) — $plugin..."
+        docker run --rm -v "$PWD/$plugin":/app -w /app -u "$UIDGID" php:8.4-cli-alpine \
+            php vendor/bin/phpstan analyse -c phpstan.neon --no-progress --memory-limit=1G "${analyzable[@]}"
+    fi
+}
+
+for plugin in sequra sequra-helper; do
+    rel=()
+    for f in "${STAGED_PHP[@]}"; do
+        case "$f" in
+            "$plugin"/*) rel+=("${f#"$plugin"/}") ;;
+        esac
+    done
+    run_checks_for_plugin "$plugin" ${rel[@]+"${rel[@]}"}
+done
+
+# Re-stage whatever phpcbf fixed so the fixes are committed.
+git add -- "${STAGED_PHP[@]}"
+
+echo "✓ Pre-commit checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,6 +27,11 @@
 # the PHPUnit suite (which needs the web container, so it can't run here).
 # Scoped phpstan here trades some accuracy for speed — phpstan sees only the
 # staged files, so the full pre-push run remains the authority.
+#
+# CAVEAT (partial staging): checks run on the working-tree files, not the staged
+# index blobs, and phpcbf's fixes are re-staged with `git add`. So if you
+# `git add -p` a file and leave other hunks unstaged, those unstaged hunks get
+# swept into the commit. Stage whole files, or `git stash -k` first, to avoid it.
 
 set -euo pipefail
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# seQura WooCommerce pre-push quality gate — mirrors the CI lint / static
+# analysis gate (.github/workflows/php-qa.yml).
+#
+# Shipped in the repo and enabled by ./setup.sh via:
+#     git config core.hooksPath .githooks
+# Bypass once with:
+#     git push --no-verify
+#
+# Runs the comprehensive checks that are too heavy (or can't be scoped to
+# staged files) for the pre-commit hook — the same ones CI runs:
+#   1. PHP syntax sweep across every supported version (7.3-8.4) over the pushed
+#      .php files, using throwaway php:<ver>-cli-alpine images (the FIRST push
+#      pulls them). Pre-commit only lints 7.3; this is the full sweep.
+#   2. Full phpcs (WordPress standard) over both plugins — via bin/phpcs.
+#   3. Full phpstan over both plugins — via bin/phpstan.
+#   4. Full PHPUnit suite — via the web container (run-tests.sh), matching
+#      .github/workflows/unit-tests.yml.
+#
+# The Playwright E2E suite is intentionally NOT run here: it needs a public
+# tunnel (--cloudflared/--ngrok) for seQura's checkout callbacks — unsuitable
+# for an automatic hook.
+#
+# The hook inspects the commits being pushed and SKIPS when none touch PHP code
+# or the config that drives the checks (composer.json/lock, phpstan.neon,
+# .phpcs.xml.dist, phpunit.xml.dist) — a docs-only push runs nothing.
+#
+# phpcs and phpstan run in throwaway php:8.4-cli-alpine images (bin/phpcs,
+# bin/phpstan) with each plugin mounted — no running dev container is required,
+# but each plugin's vendor/ must be populated (./setup.sh --install).
+# PHPUnit, by contrast, runs INSIDE the "web" container (the suite is WordPress-
+# integration tests needing WP test scaffolding); if that container isn't up the
+# hook FAILS so unverified code can't be pushed — start it with ./setup.sh (the
+# one-time `docker compose exec web /usr/local/bin/setup-tests.sh` generates the
+# scaffolding) or bypass with --no-verify. Git hooks have no TTY, so
+# `docker compose exec -T` is used.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Files whose changes can affect phpcs/phpstan/phpunit results.
+RELEVANT='\.php$|/composer\.(json|lock)$|/phpstan\.neon$|/\.phpcs\.xml\.dist$|/phpunit\.xml\.dist$'
+
+EMPTY_TREE=$(git hash-object -t tree /dev/null)
+is_zero() { case "$1" in *[!0]*) return 1 ;; *) return 0 ;; esac; }
+
+# Inspect each ref being pushed (git pre-push feeds these on stdin as
+# "<local ref> <local sha> <remote ref> <remote sha>"). Accumulate the changed
+# .php files (added/copied/modified) for the syntax sweep as we go.
+relevant=0
+CHANGED_PHP=()
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    is_zero "$local_sha" && continue            # branch deletion — nothing to check
+
+    if is_zero "$remote_sha"; then
+        # New branch on the remote: diff the commits not yet on any remote.
+        oldest=$(git rev-list "$local_sha" --not --remotes | tail -1)
+        [ -z "$oldest" ] && continue            # nothing new to push
+        if base=$(git rev-parse --quiet --verify "${oldest}^" 2>/dev/null); then :; else
+            base="$EMPTY_TREE"                  # oldest is a root commit
+        fi
+    else
+        base="$remote_sha"
+    fi
+
+    if git diff --name-only "$base" "$local_sha" | grep -qE "$RELEVANT"; then
+        relevant=1
+    fi
+
+    while IFS= read -r -d '' f; do
+        CHANGED_PHP+=("$f")
+    done < <(git diff --name-only --diff-filter=ACM -z "$base" "$local_sha" -- '*.php')
+done
+
+if [ "$relevant" -eq 0 ]; then
+    echo "No PHP-relevant changes in the pushed commits — skipping phpcs/phpstan."
+    exit 0
+fi
+
+# Multi-version syntax sweep over the pushed .php files (7.3-8.4), using
+# throwaway php:<ver>-cli-alpine images. Only files still present in the working
+# tree are linted (php -l needs the content on disk; deletions are skipped).
+PHP_VERSIONS="7.3 7.4 8.0 8.1 8.2 8.3 8.4"
+SYNTAX_PHP=()
+for f in ${CHANGED_PHP[@]+"${CHANGED_PHP[@]}"}; do
+    [ -f "$f" ] && SYNTAX_PHP+=("$f")
+done
+if [ ${#SYNTAX_PHP[@]} -gt 0 ]; then
+    echo "▶ PHP syntax sweep (${PHP_VERSIONS// /, }) on ${#SYNTAX_PHP[@]} changed file(s)..."
+    for ver in $PHP_VERSIONS; do
+        echo "  php $ver..."
+        docker run --rm -v "$PWD":/app -w /app "php:${ver}-cli-alpine" \
+            sh -c 'rc=0; for f in "$@"; do php -l -n "$f" >/dev/null || rc=1; done; exit $rc' _ "${SYNTAX_PHP[@]}"
+    done
+fi
+
+# Full phpcs + phpstan run over both plugins (bin/ wrappers, throwaway images).
+# Both need each plugin's vendor/ populated.
+for plugin in sequra sequra-helper; do
+    if [ ! -x "$plugin/vendor/bin/phpstan" ]; then
+        echo "✗ $plugin/vendor is not installed — cannot run phpcs/phpstan."
+        echo "  Run ./setup.sh --install, or bypass with: git push --no-verify"
+        exit 1
+    fi
+done
+
+echo "▶ PHP_CodeSniffer (full, WordPress standard)..."
+bin/phpcs -q
+
+echo "▶ PHPStan (full analysis over both plugins)..."
+bin/phpstan --no-progress
+
+echo "▶ PHPUnit (full suite, in the web container)..."
+if ! docker compose exec -T web true >/dev/null 2>&1; then
+    echo "✗ Docker 'web' service is not running — cannot run PHPUnit."
+    echo "  Start it with ./setup.sh (one-time scaffolding:"
+    echo "  docker compose exec web /usr/local/bin/setup-tests.sh),"
+    echo "  or bypass with: git push --no-verify"
+    exit 1
+fi
+docker compose exec -T web /usr/local/bin/run-tests.sh
+
+echo "✓ Pre-push checks passed."

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@ auth.json
 zip/
 docker/xdebug
 .actrc
-.claude/
-CLAUDE.md
-.sdd/
-.claude/commands/
-.claude/skills/
+
+# Claude files
+CLAUDE.local.md
+.claude/settings.local.json
+.claude/cache/
+.claude/tmp/
+.claude/logs/
+.claude/artifacts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Working principles
+
+These reduce the most common ways an LLM goes wrong in this codebase. They favor thoughtfulness over speed; use judgment on trivial work.
+
+**Think before coding.** State assumptions explicitly; if uncertain, ask. When a request has multiple reasonable interpretations, surface the tradeoffs instead of silently picking one. Name confusion rather than proceeding on a guess — this plugin wires into an external `integration-core` package whose contracts you cannot change, so a wrong assumption about where a behavior lives wastes a whole edit.
+
+**Simplicity first.** Deliver what was asked, not speculative features. Skip new abstractions for single-use code. If you wrote 200 lines and 50 would do, rewrite it. The codebase already has a service/controller/repository structure — fit into it rather than inventing a parallel one.
+
+**Surgical changes.** Touch only code tied to the request. Match the surrounding style (see naming conventions below) and do not refactor unrelated code. Remove only the imports/methods your own change made obsolete.
+
+**Goal-driven execution.** Turn the request into verifiable success criteria (a passing test, a clean `bin/phpcs`/`bin/phpstan` run, a working checkout in the Docker env). For multi-step work, state a brief plan with checkpoints before diving in.
+
+## Repository layout
+
+This repo holds **two WordPress plugins** plus the Docker dev harness around them:
+
+- `sequra/` — the production **seQura Payment Gateway for WooCommerce** plugin (the one published to wordpress.org). This is where almost all real work happens.
+- `sequra-helper/` — a dev/test-only companion plugin exposing helpers (configure dummy merchants, clear config, force a checkout failure, fill/clear logs, set theme/cart/checkout page versions). Not shipped to users.
+- root (`setup.sh`, `teardown.sh`, `docker/`, `docker-compose*.yml`, `bin/`, `.env`) — the dockerized local environment and CLI wrappers.
+
+## Architecture (the big picture)
+
+The plugin is a **thin WooCommerce adapter over the shared `sequra/integration-core` Composer package** (`require: sequra/integration-core ~5.1.0`). All cross-platform business logic (order creation, webhooks, ORM, task queue, settings domain, DI container) lives in that vendored core under the `SeQura\Core\*` namespace. This repo (`SeQura\WC\*`) supplies WooCommerce-specific implementations and hooks.
+
+Key consequences for any change:
+
+- **DI via `ServiceRegister`.** `sequra/src/class-bootstrap.php` extends the core's `BootstrapComponent` and is the single place where WC implementations are bound to core interfaces. To swap or add a service, register it here — do not `new` services directly. Services are resolved with `ServiceRegister::getService(SomeInterface::class)`.
+- **Interface contracts come from the core, implementations live here.** The core declares contracts like `ProductServiceInterface`, `DisconnectServiceInterface`, `MerchantDataProviderInterface`, `OrderCreationInterface` under `SeQura\Core\BusinessLogic\Domain\Integration\*`. This repo implements them under:
+  - `sequra/src/Core/Implementation/` — concrete WC implementations of core integration interfaces.
+  - `sequra/src/Core/Extension/` — WC-specific *extensions* of core domain types (e.g. the `Create_Order_Request_Builder` and `Order_Status_Settings_Service`).
+- **`sequra/src/Services/*`** — the WooCommerce domain services (`Cart`, `Order`, `Payment`, `Product`, `Shopper`, `Report`, `Widgets`, `Settings`, `Pricing`, `I18n`, `Log`, `Migration`, plus `Constants`). These are the god nodes of the codebase; most features touch one of them.
+- **`sequra/src/Controllers/Hooks/*`** — controllers registered against WordPress/WooCommerce hooks (Order, Payment, Product, Settings, Asset, Process, I18n). **`sequra/src/Controllers/Rest/*`** — REST controllers that back the admin React UI.
+- **Admin UI is external.** The settings/onboarding screens are the `sequra-core-admin-fe` package (npm dep `github:sequra/integration-core-ui`). `npm run build` copies its `dist` into `sequra/assets/integration-core-ui/`; the REST controllers above are its backend.
+- **Persistence via the core ORM.** Entities and `RepositoryRegistry` come from the core; schema changes are versioned migrations in `sequra/src/Repositories/Migrations/` (e.g. `Migration_Install_430`). Add a new migration class rather than altering tables ad hoc.
+
+### Naming conventions (do not mix)
+
+- `SeQura\WC\*` (this repo) follows **WordPress coding standards**: classes are `Underscore_Cased`, files are `class-foo.php`, methods are `snake_case`. PHPCS enforces this.
+- `SeQura\Core\*` (vendored core) is **PSR-style** `CamelCase`. Never edit files under `vendor/`.
+
+## Local development environment
+
+Everything runs in Docker; you rarely run PHP/Node directly on the host.
+
+```bash
+./setup.sh              # start WP + WooCommerce + MariaDB; prints the wp-admin URL and credentials
+./setup.sh --install    # also install composer/npm deps and build assets (first run / after dep changes)
+./setup.sh --cloudflared --cloudflared-token=TOKEN   # expose the site publicly (required for E2E callbacks)
+./setup.sh --ngrok --ngrok-token=TOKEN               # alternative public tunnel
+./teardown.sh           # stop and clean up the environment
+```
+
+Configuration is read from `.env` (copied from `.env.sample` on first run) — duplicate and rename `.env.sample` to customize WordPress/WooCommerce/PHP/MariaDB versions before running `setup.sh`.
+
+### Building front-end assets (run inside `sequra/`)
+
+```bash
+npm run build   # production: copy integration-core-ui dist, webpack (production), compile + minify SCSS
+npm run dev     # development: same, webpack dev mode with progress, non-minified SCSS
+```
+
+### Quality assurance (CLI wrappers in `bin/`, run from repo root)
+
+These wrap dockerized `php:8.4-cli-alpine` and run against **both** `sequra/` and `sequra-helper/`:
+
+```bash
+bin/php-syntax-check --php=7.3   # syntax-lint across the supported PHP matrix (7.3–8.4)
+bin/phpcs                        # PHPCS, standard .phpcs.xml.dist (WP coding standards)
+bin/phpcbf                       # auto-fix PHPCS violations
+bin/phpstan                      # PHPStan, config phpstan.neon, level set per project
+```
+
+Run `bin/phpcs` and `bin/phpstan` before considering a PHP change done — CI (`.github/workflows/php-qa.yml`) gates on both.
+
+### Unit & integration tests
+
+Tests run **inside the `web` container** (the plugin is mounted at `/var/www/html/wp-content/plugins/_sequra`):
+
+```bash
+docker compose exec web /usr/local/bin/setup-tests.sh    # one-time: generate WP test scaffolding
+docker compose exec web /usr/local/bin/run-tests.sh      # run the full PHPUnit suite (--testdox)
+```
+
+Run a single test or file (PHPUnit `--filter` / path):
+
+```bash
+docker compose exec web bash -c \
+  'cd /var/www/html/wp-content/plugins/_sequra && vendor/bin/phpunit -c ./phpunit.xml.dist --filter testMethodName'
+```
+
+PHPUnit config: `sequra/phpunit.xml.dist`. Test sources live under `sequra/tests/` (`Controllers/`, `Core/`, `Fixtures/`, `Repositories/`, `Services/`), autoloaded via `composer.json` classmaps.
+
+### End-to-end tests (Playwright)
+
+E2E requires the store to be reachable from the internet (seQura performs checkout callbacks), so start the env with `--cloudflared` or `--ngrok` first.
+
+```bash
+bin/playwright                      # headless run of sequra/tests-e2e specs (sources .env, runs `npx playwright test`)
+bin/playwright --ui                 # UI mode
+bin/playwright path/to/spec.spec.js # a single spec; any extra args pass through to `playwright test`
+```
+
+## Specs and ticket workflow
+
+Design specs for in-flight work live in `.sdd/specs/` keyed by JIRA ticket (e.g. `PAR-740.md`, `PAR-773.md`, `PAR-781.md`); `.sdd/specs/tmp/` holds investigation notes (e.g. the TIJ-4222 order-pay loop diagnosis). Read the relevant spec before implementing a ticketed change. Branch names encode the ticket (e.g. `chore/PAR-805-...`), and PRs follow `.github/PULL_REQUEST_TEMPLATE.md`.
+
+The plugin version lives in **two** places that must stay in sync when releasing: the header in `sequra/sequra.php` and the changelog/stable tag in `sequra/readme.txt`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,5 @@ E2E requires the store to be reachable from the internet (seQura performs checko
 bin/playwright                      # headless run of sequra/tests-e2e specs (sources .env, runs `npx playwright test`)
 bin/playwright --ui                 # UI mode
 bin/playwright path/to/spec.spec.js # a single spec; any extra args pass through to `playwright test`
-```
+``
 
-## Specs and ticket workflow
-
-Design specs for in-flight work live in `.sdd/specs/` keyed by JIRA ticket (e.g. `PAR-740.md`, `PAR-773.md`, `PAR-781.md`); `.sdd/specs/tmp/` holds investigation notes (e.g. the TIJ-4222 order-pay loop diagnosis). Read the relevant spec before implementing a ticketed change. Branch names encode the ticket (e.g. `chore/PAR-805-...`), and PRs follow `.github/PULL_REQUEST_TEMPLATE.md`.
-
-The plugin version lives in **two** places that must stay in sync when releasing: the header in `sequra/sequra.php` and the changelog/stable tag in `sequra/readme.txt`.

--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,9 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+# Enable the repo's shared git hooks (pre-commit / pre-push quality gates).
+git -C "$BASEDIR" config core.hooksPath .githooks
+
 # Extract WP_URL from .env and set PUBLIC_URL to that value
 WP_URL=$(grep '^WP_URL=' .env | cut -d'=' -f2)
 sed -i.bak "s|PUBLIC_URL=.*|PUBLIC_URL=$WP_URL|" .env


### PR DESCRIPTION
### What is the goal?

Bring this repo in line with the Claude Code tooling added to `integration-core` and `magento2-core` (PAR-805): a tracked permission policy, shared git hooks that mirror the CI quality gates, a release helper skill, and codebase guidance — all adapted to this repo's two-plugin layout, `bin/` wrappers and CI.

### References

- **Issue:** https://sequra.atlassian.net/browse/PAR-805

### How is it being implemented?

- **`.claude/settings.json`** — tracked permission policy scoped to this repo's `bin/` wrappers (`phpcs`, `phpcbf`, `phpstan`, `php-syntax-check`, `composer`, `npm`, `playwright`), read-only `git` commands, and the `sq-git:*` skills; denies `.env*`/keys; asks before `setup.sh`/`teardown.sh`/`git push`.
- **`.githooks/pre-commit`** — on staged `.php` files: PHP 7.3 syntax (the language floor) + `phpcbf`→`phpcs` + scoped `phpstan`, per plugin, in throwaway Docker images (no running container needed).
- **`.githooks/pre-push`** — mirrors the CI gate: 7.3–8.4 syntax sweep + full `phpcs` + full `phpstan` (via the `bin/` wrappers) + the PHPUnit suite (inside the `web` container, like `unit-tests.yml`). Skips docs-only pushes.
- **`setup.sh`** — enables the shared hooks via `git config core.hooksPath .githooks`.
- **`.claude/skills/version-bump/SKILL.md`** — release skill for the two coupled version locations in this repo (`sequra/sequra.php` header + `sequra/readme.txt` stable tag/changelog).
- **`CLAUDE.md`** — codebase guidance for Claude Code.

`.gitattributes` from the sibling PRs was intentionally omitted: the distribution zip is built by `bin/make_zip` (clone + `rm` + zip of only `sequra/`), which doesn't use `git archive`, so `export-ignore` would be dead config here — these root-level files are already excluded from the published plugin.

### Caveats

- **Pre-push depends on a running, scaffolded `web` container** for PHPUnit. The first push after `./setup.sh` also needs the one-time `docker compose exec web /usr/local/bin/setup-tests.sh`. If the container is down the push fails by design; bypass with `git push --no-verify`.
- **Scoped pre-commit PHPStan** sees only the staged files, so it can surface false positives the full pre-push run won't — the full run remains the authority.

### How is it tested?

- Both hooks pass `bash -n`; `settings.json` validated as JSON.
- Every command reference verified to exist and resolve correctly: the `bin/` wrappers, the per-plugin vendored `phpcs`/`phpcbf`/`phpstan`, the `phpcs`/`phpstan` configs, and the `web` `run-tests.sh` runner.
- Hook checks and the 7.3–8.4 version matrix confirmed to match `.github/workflows/php-qa.yml` and `unit-tests.yml`.

### How is it going to be deployed?

Standard deployment. Developer-only tooling — not part of the published plugin artifact (`bin/make_zip` ships only `sequra/`).