### PR TITLE
[PAR-811] Audit Shopper Country Resolution

### DIFF
--- a/sequra/package-lock.json
+++ b/sequra/package-lock.json
@@ -21,7 +21,7 @@
                 "babel-loader": "~8.2.0",
                 "css-loader": "~6.7.0",
                 "cssnano": "~5.1.0",
-                "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.3.4",
+                "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.4.0",
                 "postcss-cli": "~9.1.0",
                 "postcss-loader": "~6.2.0",
                 "sass": "~1.49.0",
@@ -16153,8 +16153,8 @@
             }
         },
         "node_modules/playwright-fixture-for-plugins": {
-            "version": "1.3.4",
-            "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#b3c47e8168187f506430e48979615a809dd96620",
+            "version": "1.4.0",
+            "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#a60d8a458f6820004a9f25856b45515550adf2a2",
             "dev": true
         },
         "node_modules/playwright/node_modules/fsevents": {

--- a/sequra/package-lock.json
+++ b/sequra/package-lock.json
@@ -21,7 +21,7 @@
                 "babel-loader": "~8.2.0",
                 "css-loader": "~6.7.0",
                 "cssnano": "~5.1.0",
-                "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.3.2",
+                "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.3.4",
                 "postcss-cli": "~9.1.0",
                 "postcss-loader": "~6.2.0",
                 "sass": "~1.49.0",
@@ -78,7 +78,6 @@
             "integrity": "sha512-44ODe6O1IVz9s2oJE3rZ4trNNKTX9O7KpQpfAP4t8QII/zwrVRHL7i2pxhqtcY7tqMLrrKfMlBKnm1QlrRFs5w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
@@ -3139,7 +3138,6 @@
             "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "playwright": "1.57.0"
             },
@@ -3672,7 +3670,6 @@
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -3857,7 +3854,6 @@
             "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -4217,7 +4213,6 @@
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -4561,7 +4556,6 @@
             "integrity": "sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/tapable": "^1",
@@ -4686,7 +4680,6 @@
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -6129,7 +6122,6 @@
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -6294,7 +6286,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6378,7 +6369,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -7354,7 +7344,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -9575,7 +9564,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -9632,7 +9620,6 @@
             "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -13134,7 +13121,6 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -14273,8 +14259,7 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
             "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
             "version": "8.13.0",
@@ -15351,7 +15336,6 @@
             "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.6",
                 "ajv-errors": "^1.0.1",
@@ -16169,10 +16153,9 @@
             }
         },
         "node_modules/playwright-fixture-for-plugins": {
-            "version": "1.3.2",
-            "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#049bcdedff1633efca122fd616fae5074cbf08a6",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.3.4",
+            "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#b3c47e8168187f506430e48979615a809dd96620",
+            "dev": true
         },
         "node_modules/playwright/node_modules/fsevents": {
             "version": "2.3.2",
@@ -16235,7 +16218,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -16986,7 +16968,6 @@
             "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -17201,7 +17182,6 @@
             "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -17687,7 +17667,6 @@
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -17723,7 +17702,6 @@
             "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18458,6 +18436,7 @@
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -18488,7 +18467,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -19638,7 +19616,6 @@
             "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@csstools/selector-specificity": "^2.0.2",
                 "balanced-match": "^2.0.0",
@@ -20452,7 +20429,6 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -21005,7 +20981,6 @@
             "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -21114,7 +21089,6 @@
             "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.1.1",
@@ -21193,7 +21167,6 @@
             "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",

--- a/sequra/package.json
+++ b/sequra/package.json
@@ -37,6 +37,7 @@
         "babel-loader": "~8.2.0",
         "css-loader": "~6.7.0",
         "cssnano": "~5.1.0",
+        "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.3.4",
         "postcss-cli": "~9.1.0",
         "postcss-loader": "~6.2.0",
         "sass": "~1.49.0",
@@ -45,8 +46,7 @@
         "style-loader": "^3.3.1",
         "terser-webpack-plugin": "~5.3.0",
         "webpack": "^5.89.0",
-        "webpack-cli": "~4.9.0",
-        "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.3.2"
+        "webpack-cli": "~4.9.0"
     },
     "dependencies": {
         "sequra-core-admin-fe": "github:sequra/integration-core-ui#2.2.0"

--- a/sequra/package.json
+++ b/sequra/package.json
@@ -37,7 +37,7 @@
         "babel-loader": "~8.2.0",
         "css-loader": "~6.7.0",
         "cssnano": "~5.1.0",
-        "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.3.4",
+        "playwright-fixture-for-plugins": "github:sequra/playwright-fixture-for-plugins#1.4.0",
         "postcss-cli": "~9.1.0",
         "postcss-loader": "~6.2.0",
         "sass": "~1.49.0",

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -103,7 +103,7 @@ Contributors:
 = 4.3.3	=
 * Fixed: During guest checkout the shopper country now falls back from the shipping address to the billing address, so seQura no longer disappears when only a billing country is set.
 * Changed: When the shopper country cannot be determined, seQura is no longer shown with a guessed country and stays hidden until an address country is available, preventing wrong-country solicitations.
-* Changed: The sequra_shopper_country filter is now applied consistently to the country used for checkout availability and the solicitation.
+* Changed: The sequra_shopper_country filter is now applied consistently to the country used for checkout availability and the solicitation, and the resolved country is normalized to uppercase (ISO-3166-1 alpha-2) so case differences no longer affect payment method availability or merchant selection.
 = 4.3.2	=
 * Fixed: Locale detection now correctly prioritizes active multilingual plugins (Polylang, qTranslate, WPML) before falling back to the site or user locale.
 * Fixed: Empty or malformed store integration webhook request bodies now return a 400 response instead of a 500 error.

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -102,8 +102,8 @@ Contributors:
 == Changelog ==
 = 4.3.3	=
 * Fixed: During guest checkout the shopper country now falls back from the shipping address to the billing address, so seQura no longer disappears when only a billing country is set.
-* Changed: When the shopper country cannot be determined, seQura is no longer shown with a guessed country and stays hidden until an address country is available, preventing wrong-country solicitations.
-* Changed: The sequra_shopper_country filter is now applied consistently to the country used for checkout availability and the solicitation, and the resolved country is normalized to uppercase (ISO-3166-1 alpha-2) so case differences no longer affect payment method availability or merchant selection.
+* Fixed: The shopper country is normalized to uppercase (ISO-3166-1 alpha-2), so case differences no longer prevent payment methods from showing or the correct merchant from being selected.
+* Changed: The order request no longer defaults a missing delivery or invoice country to Spain, and the sequra_shopper_country filter is now applied consistently to the resolved shopper country used for availability and the solicitation.
 = 4.3.2	=
 * Fixed: Locale detection now correctly prioritizes active multilingual plugins (Polylang, qTranslate, WPML) before falling back to the site or user locale.
 * Fixed: Empty or malformed store integration webhook request bodies now return a 400 response instead of a 500 error.

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -100,6 +100,10 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 Contributors:
 == Changelog ==
+= 4.3.3	=
+* Fixed: During guest checkout the shopper country now falls back from the shipping address to the billing address, so seQura no longer disappears when only a billing country is set.
+* Changed: When the shopper country cannot be determined, seQura is no longer shown with a guessed country and stays hidden until an address country is available, preventing wrong-country solicitations.
+* Changed: The sequra_shopper_country filter is now applied consistently to the country used for checkout availability and the solicitation.
 = 4.3.2	=
 * Fixed: Locale detection now correctly prioritizes active multilingual plugins (Polylang, qTranslate, WPML) before falling back to the site or user locale.
 * Fixed: Empty or malformed store integration webhook request bodies now return a 400 response instead of a 500 error.

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -102,6 +102,7 @@ Contributors:
 == Changelog ==
 = 4.3.3	=
 * Fixed: During guest checkout the shopper country now falls back from the shipping address to the billing address, so seQura no longer disappears when only a billing country is set.
+* Fixed: During guest checkout the shopper state and city now fall back from the shipping address to the billing address (matching the country), so the solicitation receives complete address data.
 * Fixed: The shopper country is normalized to uppercase (ISO-3166-1 alpha-2), so case differences no longer prevent payment methods from showing or the correct merchant from being selected.
 * Changed: The order request no longer defaults a missing delivery or invoice country to Spain, and the sequra_shopper_country filter is now applied consistently to the resolved shopper country used for availability and the solicitation.
 = 4.3.2	=

--- a/sequra/sequra.php
+++ b/sequra/sequra.php
@@ -8,7 +8,7 @@
  * Plugin Name:       seQura
  * Plugin URI:        https://sequra.es/
  * Description:       seQura payment gateway for WooCommerce
- * Version:           4.3.2
+ * Version:           4.3.3-rc.1
  * Author:            "seQura Tech" <wordpress@sequra.com>
  * Author URI:        https://sequra.com/
  * License:           GPL-3.0+

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
@@ -512,6 +512,8 @@ class Create_Order_Request_Builder implements Interface_Create_Order_Request_Bui
 			}
 		}
 
-		return strval( $this->i18n->get_lang() );
+		// No silent fallback: an unresolved country must hide seQura via availability gating
+		// rather than guessing a country (locale or store base) and sending a wrong solicitation.
+		return null;
 	}
 }

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
@@ -374,7 +374,11 @@ class Create_Order_Request_Builder implements Interface_Create_Order_Request_Bui
 		 */
 		return \apply_filters(
 			'sequra_create_order_request_' . ( $is_delivery ? 'delivery_address' : 'invoice_address' ) . '_options',
-			$this->address_builder->build( $this->current_order_provider->get(), $is_delivery )
+			$this->address_builder->build(
+				$this->current_order_provider->get(),
+				$is_delivery,
+				$this->get_country( $this->get_cart_ref_from_order_or_cart() )
+			)
 		);
 	}
 

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
@@ -512,13 +512,6 @@ class Create_Order_Request_Builder implements Interface_Create_Order_Request_Bui
 			}
 		}
 
-		/**
-		 * Allow changing the country of the shopper.
-		 *
-		 * @since 3.0.7
-		 * @param string|null $country The country code.
-		 * @return string The country code. Must be in ISO-3166-1 alpha-2 format.
-		 */
-		return strval( apply_filters( 'sequra_shopper_country', $this->i18n->get_lang() ) );
+		return strval( $this->i18n->get_lang() );
 	}
 }

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
@@ -512,8 +512,9 @@ class Create_Order_Request_Builder implements Interface_Create_Order_Request_Bui
 			}
 		}
 
-		// No silent fallback: an unresolved country must hide seQura via availability gating
-		// rather than guessing a country (locale or store base) and sending a wrong solicitation.
-		return null;
+		// Last resort: derive the country from the locale, uppercased to match the
+		// case-sensitive credentials/country config. The sequra_shopper_country filter
+		// already had its chance during the order/cart resolution above.
+		return strtoupper( strval( $this->i18n->get_lang() ) );
 	}
 }

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
@@ -515,6 +515,13 @@ class Create_Order_Request_Builder implements Interface_Create_Order_Request_Bui
 		// Last resort: derive the country from the locale, uppercased to match the
 		// case-sensitive credentials/country config. The sequra_shopper_country filter
 		// already had its chance during the order/cart resolution above.
-		return strtoupper( strval( $this->i18n->get_lang() ) );
+		$country = strtoupper( strval( $this->i18n->get_lang() ) );
+		$this->logger->log_debug(
+			'Country not found in order/cart or stored order; falling back to locale',
+			__FUNCTION__,
+			__CLASS__,
+			array( new LogContextData( 'country', $country ) )
+		);
+		return $country;
 	}
 }

--- a/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
+++ b/sequra/src/Core/Implementation/BusinessLogic/Domain/Order/Builders/class-create-order-request-builder.php
@@ -488,7 +488,7 @@ class Create_Order_Request_Builder implements Interface_Create_Order_Request_Bui
 	/**
 	 * Get country code from cart ID or current order/session
 	 */
-	private function get_country( ?string $cart_id = null ): ?string {
+	public function get_country( ?string $cart_id = null ): ?string {
 		// Priority 1: live data from the current order/cart/session (always fresh).
 		try {
 			return $this->get_country_from_order_or_cart();

--- a/sequra/src/Services/I18n/class-i18n.php
+++ b/sequra/src/Services/I18n/class-i18n.php
@@ -64,12 +64,11 @@ class I18n implements Interface_I18n {
 	}
 
 	/**
-	 * TODO: Make Unit Test for this
 	 * Get the current country. ISO-3166-1 alpha-2 code.
-	 * Looks for the country in the following order:
-	 * 1. The country set in WooCommerce checkout billing address.
-	 * 2. The country set in user profile.
-	 * 3. The country by current locale.
+	 * Resolution order: shipping country, billing country, user-profile billing country, current locale.
+	 *
+	 * Widget-surface country resolver and the single point that applies the sequra_shopper_country
+	 * filter for promotional widgets; the checkout/solicitation path applies it in the shopper service.
 	 */
 	public function get_current_country(): string {
 		$country = null;

--- a/sequra/src/Services/Order/Builder/class-order-address-builder.php
+++ b/sequra/src/Services/Order/Builder/class-order-address-builder.php
@@ -35,9 +35,14 @@ class Order_Address_Builder implements Interface_Order_Address_Builder {
 
 	/**
 	 * Get address
+	 *
+	 * @param ?string $fallback_country Country used when the address itself resolves none (e.g. address-less service flows), so the solicitation still carries a country.
 	 */
-	public function build( ?WC_Order $order, bool $is_delivery ): Address {
+	public function build( ?WC_Order $order, bool $is_delivery, ?string $fallback_country = null ): Address {
 		$country = $this->shopper_service->get_country( $order, $is_delivery );
+		if ( ! $country ) {
+			$country = (string) $fallback_country;
+		}
 		return new Address(
 			$this->shopper_service->get_company( $order, $is_delivery ),
 			$this->shopper_service->get_address_1( $order, $is_delivery ),

--- a/sequra/src/Services/Order/Builder/class-order-address-builder.php
+++ b/sequra/src/Services/Order/Builder/class-order-address-builder.php
@@ -44,7 +44,7 @@ class Order_Address_Builder implements Interface_Order_Address_Builder {
 			$this->shopper_service->get_address_2( $order, $is_delivery ),
 			$this->shopper_service->get_postcode( $order, $is_delivery ),
 			$this->shopper_service->get_city( $order, $is_delivery ),
-			$country ? $country : 'ES',
+			$country,
 			$this->shopper_service->get_first_name( $order, $is_delivery ),
 			$this->shopper_service->get_last_name( $order, $is_delivery ),
 			null, // phone.

--- a/sequra/src/Services/Order/Builder/interface-order-address-builder.php
+++ b/sequra/src/Services/Order/Builder/interface-order-address-builder.php
@@ -18,6 +18,8 @@ interface Interface_Order_Address_Builder {
 
 	/**
 	 * Get address
+	 *
+	 * @param ?string $fallback_country Country used when the address itself resolves none.
 	 */
-	public function build( ?WC_Order $order, bool $is_delivery ): Address;
+	public function build( ?WC_Order $order, bool $is_delivery, ?string $fallback_country = null ): Address;
 }

--- a/sequra/src/Services/Shopper/class-shopper-service.php
+++ b/sequra/src/Services/Shopper/class-shopper-service.php
@@ -313,8 +313,16 @@ class Shopper_Service implements Interface_Shopper_Service {
 	 * Get client country code. If the order is null, attempt to retrieve data from the session.
 	 */
 	public function get_country( ?WC_Order $order, $is_delivery = true ): string {
-		$prefix = $is_delivery ? 'shipping' : 'billing';
-		return $this->get_customer_field( $order, "get_{$prefix}_country", 'get_billing_country', "{$prefix}_country", 'billing_country' );
+		$prefix  = $is_delivery ? 'shipping' : 'billing';
+		$country = $this->get_customer_field( $order, "get_{$prefix}_country", 'get_billing_country', "{$prefix}_country", 'billing_country' );
+		/**
+		 * Allow changing the country of the shopper.
+		 *
+		 * @since 3.0.7
+		 * @param string|null $country The country code.
+		 * @return string The country code. Must be in ISO-3166-1 alpha-2 format.
+		 */
+		return strval( \apply_filters( 'sequra_shopper_country', $country ) );
 	}
 
 	/**

--- a/sequra/src/Services/Shopper/class-shopper-service.php
+++ b/sequra/src/Services/Shopper/class-shopper-service.php
@@ -334,7 +334,7 @@ class Shopper_Service implements Interface_Shopper_Service {
 		if ( ! $state_code ) {
 			return '';
 		}
-		$states = WC()->countries->get_states( $this->get_country( $order ) );
+		$states = WC()->countries->get_states( $this->get_country( $order, $is_delivery ) );
 		if ( ! $states || ! isset( $states[ $state_code ] ) ) {
 			return '';
 		}

--- a/sequra/src/Services/Shopper/class-shopper-service.php
+++ b/sequra/src/Services/Shopper/class-shopper-service.php
@@ -302,7 +302,7 @@ class Shopper_Service implements Interface_Shopper_Service {
 	 */
 	public function get_city( ?WC_Order $order, $is_delivery = true ): string {
 		$prefix = $is_delivery ? 'shipping' : 'billing';
-		$city   = $this->get_customer_field( $order, "get_{$prefix}_city", 'get_billing_city', "{$prefix}_city", 'city' );
+		$city   = $this->get_customer_field( $order, "get_{$prefix}_city", 'get_billing_city', "{$prefix}_city", 'billing_city' );
 		if ( ! $city ) {
 			$city = $this->get_customer_field( $order, 'get_city', 'get_city', 'city', 'city' );
 		}
@@ -330,7 +330,7 @@ class Shopper_Service implements Interface_Shopper_Service {
 	 */
 	public function get_state( ?WC_Order $order, $is_delivery = true ): string {
 		$prefix     = $is_delivery ? 'shipping' : 'billing';
-		$state_code = $this->get_customer_field( $order, "get_{$prefix}_state", 'get_billing_state', "{$prefix}_state", 'state' );
+		$state_code = $this->get_customer_field( $order, "get_{$prefix}_state", 'get_billing_state', "{$prefix}_state", 'billing_state' );
 		if ( ! $state_code ) {
 			return '';
 		}

--- a/sequra/src/Services/Shopper/class-shopper-service.php
+++ b/sequra/src/Services/Shopper/class-shopper-service.php
@@ -322,7 +322,7 @@ class Shopper_Service implements Interface_Shopper_Service {
 		 * @param string|null $country The country code.
 		 * @return string The country code. Must be in ISO-3166-1 alpha-2 format.
 		 */
-		return strval( \apply_filters( 'sequra_shopper_country', $country ) );
+		return strtoupper( strval( \apply_filters( 'sequra_shopper_country', $country ) ) );
 	}
 
 	/**

--- a/sequra/src/Services/Shopper/class-shopper-service.php
+++ b/sequra/src/Services/Shopper/class-shopper-service.php
@@ -314,7 +314,7 @@ class Shopper_Service implements Interface_Shopper_Service {
 	 */
 	public function get_country( ?WC_Order $order, $is_delivery = true ): string {
 		$prefix = $is_delivery ? 'shipping' : 'billing';
-		return $this->get_customer_field( $order, "get_{$prefix}_country", 'get_billing_country', "{$prefix}_country", 'country' );
+		return $this->get_customer_field( $order, "get_{$prefix}_country", 'get_billing_country', "{$prefix}_country", 'billing_country' );
 	}
 
 	/**

--- a/sequra/tests/Core/Implementation/BusinessLogic/Domain/Order/Builders/CreateOrderRequestBuilderTest.php
+++ b/sequra/tests/Core/Implementation/BusinessLogic/Domain/Order/Builders/CreateOrderRequestBuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for Create_Order_Request_Builder country resolution.
+ *
+ * @package    SeQura/WC
+ * @subpackage SeQura/WC/Tests
+ */
+
+namespace SeQura\WC\Tests\Core\Implementation\BusinessLogic\Domain\Order\Builders;
+
+use SeQura\Core\BusinessLogic\Domain\Connection\Services\CredentialsService;
+use SeQura\Core\BusinessLogic\Domain\Order\Builders\MerchantOrderRequestBuilder;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderRequest\Address;
+use SeQura\Core\BusinessLogic\Domain\Order\Models\SeQuraOrder;
+use SeQura\Core\BusinessLogic\Domain\Order\RepositoryContracts\SeQuraOrderRepositoryInterface;
+use SeQura\WC\Core\Implementation\BusinessLogic\Domain\Order\Builders\Create_Order_Request_Builder;
+use SeQura\WC\Services\Cart\Interface_Cart_Service;
+use SeQura\WC\Services\I18n\Interface_I18n;
+use SeQura\WC\Services\Log\Interface_Logger_Service;
+use SeQura\WC\Services\Order\Builder\Interface_Order_Address_Builder;
+use SeQura\WC\Services\Order\Builder\Interface_Order_Customer_Builder;
+use SeQura\WC\Services\Order\Builder\Interface_Order_Delivery_Method_Builder;
+use SeQura\WC\Services\Order\Interface_Current_Order_Provider;
+use SeQura\WC\Services\Order\Interface_Order_Service;
+use SeQura\WC\Services\Platform\Platform_Provider;
+use SeQura\WC\Services\Product\Interface_Product_Service;
+use SeQura\WC\Services\Shopper\Interface_Shopper_Service;
+use WP_UnitTestCase;
+
+class CreateOrderRequestBuilderTest extends WP_UnitTestCase {
+
+	private $shopper_service;
+	private $sequra_order_repository;
+	private $i18n;
+	private $current_order_provider;
+
+	/** @var Create_Order_Request_Builder */
+	private $builder;
+
+	public function set_up(): void {
+		$this->shopper_service         = $this->createMock( Interface_Shopper_Service::class );
+		$this->sequra_order_repository = $this->createMock( SeQuraOrderRepositoryInterface::class );
+		$this->i18n                    = $this->createMock( Interface_I18n::class );
+		$this->current_order_provider  = $this->createMock( Interface_Current_Order_Provider::class );
+
+		$this->builder = new Create_Order_Request_Builder(
+			$this->createMock( Interface_Cart_Service::class ),
+			$this->createMock( Platform_Provider::class ),
+			$this->createMock( Interface_Product_Service::class ),
+			$this->createMock( Interface_Order_Service::class ),
+			$this->i18n,
+			$this->shopper_service,
+			$this->createMock( Interface_Logger_Service::class ),
+			$this->current_order_provider,
+			$this->createMock( MerchantOrderRequestBuilder::class ),
+			$this->createMock( Interface_Order_Delivery_Method_Builder::class ),
+			$this->createMock( Interface_Order_Address_Builder::class ),
+			$this->createMock( Interface_Order_Customer_Builder::class ),
+			$this->createMock( CredentialsService::class ),
+			$this->sequra_order_repository
+		);
+	}
+
+	public function testGetCountry_liveCountryAvailable_returnsIt(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( 'PT' );
+
+		$this->assertSame( 'PT', $this->builder->get_country() );
+	}
+
+	public function testGetCountry_noLiveCountry_recoversFromStoredOrderDelivery(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( '' );
+
+		$delivery = $this->createMock( Address::class );
+		$delivery->method( 'getCountryCode' )->willReturn( 'IT' );
+		$sequra_order = $this->createMock( SeQuraOrder::class );
+		$sequra_order->method( 'getDeliveryAddress' )->willReturn( $delivery );
+		$this->sequra_order_repository->method( 'getByCartId' )->willReturn( $sequra_order );
+
+		$this->assertSame( 'IT', $this->builder->get_country( 'cart-ref' ) );
+	}
+
+	public function testGetCountry_storedOrderDeliveryEmpty_usesInvoiceCountry(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( '' );
+
+		$delivery = $this->createMock( Address::class );
+		$delivery->method( 'getCountryCode' )->willReturn( '' );
+		$invoice = $this->createMock( Address::class );
+		$invoice->method( 'getCountryCode' )->willReturn( 'FR' );
+		$sequra_order = $this->createMock( SeQuraOrder::class );
+		$sequra_order->method( 'getDeliveryAddress' )->willReturn( $delivery );
+		$sequra_order->method( 'getInvoiceAddress' )->willReturn( $invoice );
+		$this->sequra_order_repository->method( 'getByCartId' )->willReturn( $sequra_order );
+
+		$this->assertSame( 'FR', $this->builder->get_country( 'cart-ref' ) );
+	}
+
+	public function testGetCountry_noLiveNoStored_fallsBackToLocaleUppercased(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( '' );
+		$this->sequra_order_repository->method( 'getByCartId' )->willReturn( null );
+		$this->i18n->method( 'get_lang' )->willReturn( 'es' );
+
+		$this->assertSame( 'ES', $this->builder->get_country( 'cart-ref' ) );
+	}
+}

--- a/sequra/tests/Repositories/Migrations/MigrationInstall300Test.php
+++ b/sequra/tests/Repositories/Migrations/MigrationInstall300Test.php
@@ -266,6 +266,11 @@ class MigrationInstall300Test extends WP_UnitTestCase {
 					'signature_secret'  => $actual_array['credentials']['payload']['signature_secret'], // Let's keep this secret.
 					'confirmation_path' => 'default',
 					'realm'             => 'sequra',
+					'affiliate'         => array(
+						'enabled'        => false,
+						'offer_id'       => null,
+						'security_token' => null,
+					),
 				),
 				'deployment' => 'sequra',
 			),

--- a/sequra/tests/Repositories/Migrations/MigrationInstall300Test.php
+++ b/sequra/tests/Repositories/Migrations/MigrationInstall300Test.php
@@ -257,7 +257,7 @@ class MigrationInstall300Test extends WP_UnitTestCase {
 					'allowed_countries' => array( 'ES' ),
 					'currency'          => 'EUR',
 					'assets_key'        => getenv( 'DUMMY_ASSETS_KEY' ),
-					'contract_options'  => array( 'allow_first_instalment_delay', 'with_registration' ),
+					'contract_options'  => array( 'allow_authorize_and_capture', 'allow_first_instalment_delay', 'with_registration' ),
 					'extra_information' => array(
 						'type'         => 'regular',
 						'phone_number' => '',

--- a/sequra/tests/Repositories/Migrations/MigrationInstall400Test.php
+++ b/sequra/tests/Repositories/Migrations/MigrationInstall400Test.php
@@ -231,6 +231,11 @@ class MigrationInstall400Test extends WP_UnitTestCase {
 						'signature_secret'  => $actual_entity['credentials']['payload']['signature_secret'], // Let's keep this secret.
 						'confirmation_path' => $actual_entity['credentials']['payload']['confirmation_path'],
 						'realm'             => $actual_entity['credentials']['payload']['realm'],
+						'affiliate'         => array(
+							'enabled'        => false,
+							'offer_id'       => null,
+							'security_token' => null,
+						),
 					),
 					'deployment' => $actual_entity['credentials']['deployment'],
 				),

--- a/sequra/tests/Services/I18n/I18nTest.php
+++ b/sequra/tests/Services/I18n/I18nTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for the I18n widget-surface country resolution.
+ *
+ * @package    SeQura/WC
+ * @subpackage SeQura/WC/Tests
+ */
+
+namespace SeQura\WC\Tests\Services\I18n;
+
+use SeQura\WC\Services\I18n\I18n;
+use WC_Customer;
+use WP_UnitTestCase;
+
+class I18nTest extends WP_UnitTestCase {
+
+	/** @var I18n */
+	private $i18n;
+
+	private $original_customer;
+
+	public function set_up(): void {
+		$this->original_customer = isset( WC()->customer ) ? WC()->customer : null;
+		$this->i18n              = new I18n();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'sequra_shopper_country' );
+		WC()->customer = $this->original_customer;
+	}
+
+	public function testGetCurrentCountry_withShippingCountry_returnsShipping(): void {
+		$customer = new WC_Customer();
+		$customer->set_shipping_country( 'FR' );
+		$customer->set_billing_country( 'ES' );
+		WC()->customer = $customer;
+
+		$this->assertSame( 'FR', $this->i18n->get_current_country() );
+	}
+
+	public function testGetCurrentCountry_shippingEmpty_fallsBackToBilling(): void {
+		$customer = new WC_Customer();
+		$customer->set_billing_country( 'IT' );
+		WC()->customer = $customer;
+
+		$this->assertSame( 'IT', $this->i18n->get_current_country() );
+	}
+
+	public function testGetCurrentCountry_filterOverridesAndUppercases(): void {
+		$customer = new WC_Customer();
+		$customer->set_shipping_country( 'ES' );
+		WC()->customer = $customer;
+
+		add_filter(
+			'sequra_shopper_country',
+			function () {
+				return 'pt';
+			}
+		);
+
+		$this->assertSame( 'PT', $this->i18n->get_current_country() );
+	}
+}

--- a/sequra/tests/Services/Order/Builder/OrderAddressBuilderTest.php
+++ b/sequra/tests/Services/Order/Builder/OrderAddressBuilderTest.php
@@ -40,4 +40,20 @@ class OrderAddressBuilderTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'PT', $address->getCountryCode() );
 	}
+
+	public function testBuild_emptyCountry_usesFallbackCountry(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( '' );
+
+		$address = $this->builder->build( null, true, 'IT' );
+
+		$this->assertSame( 'IT', $address->getCountryCode() );
+	}
+
+	public function testBuild_resolvedCountry_ignoresFallback(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( 'PT' );
+
+		$address = $this->builder->build( null, true, 'IT' );
+
+		$this->assertSame( 'PT', $address->getCountryCode() );
+	}
 }

--- a/sequra/tests/Services/Order/Builder/OrderAddressBuilderTest.php
+++ b/sequra/tests/Services/Order/Builder/OrderAddressBuilderTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Tests for the Order Address Builder country handling.
+ *
+ * @package    SeQura/WC
+ * @subpackage SeQura/WC/Tests
+ */
+
+namespace SeQura\WC\Tests\Services\Order\Builder;
+
+use SeQura\WC\Services\Order\Builder\Order_Address_Builder;
+use SeQura\WC\Services\Shopper\Interface_Shopper_Service;
+use WP_UnitTestCase;
+
+class OrderAddressBuilderTest extends WP_UnitTestCase {
+
+	/** @var Interface_Shopper_Service */
+	private $shopper_service;
+
+	/** @var Order_Address_Builder */
+	private $builder;
+
+	public function set_up(): void {
+		$this->shopper_service = $this->createMock( Interface_Shopper_Service::class );
+		$this->builder         = new Order_Address_Builder( $this->shopper_service );
+	}
+
+	public function testBuild_emptyCountry_isNotDefaultedToSpain(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( '' );
+
+		$address = $this->builder->build( null, true );
+
+		$this->assertSame( '', $address->getCountryCode() );
+	}
+
+	public function testBuild_resolvedCountry_isUsed(): void {
+		$this->shopper_service->method( 'get_country' )->willReturn( 'PT' );
+
+		$address = $this->builder->build( null, true );
+
+		$this->assertSame( 'PT', $address->getCountryCode() );
+	}
+}

--- a/sequra/tests/Services/Shopper/ShopperServiceTest.php
+++ b/sequra/tests/Services/Shopper/ShopperServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for the Shopper service country resolution.
+ *
+ * @package    SeQura/WC
+ * @subpackage SeQura/WC/Tests
+ */
+
+namespace SeQura\WC\Tests\Services\Shopper;
+
+use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
+use SeQura\WC\Services\Shopper\Shopper_Service;
+use WC_Customer;
+use WC_Order;
+use WP_UnitTestCase;
+
+class ShopperServiceTest extends WP_UnitTestCase {
+
+	/** @var Shopper_Service */
+	private $shopper_service;
+
+	private $original_customer;
+
+	public function set_up(): void {
+		$this->original_customer = isset( WC()->customer ) ? WC()->customer : null;
+		$this->shopper_service   = new Shopper_Service( $this->createMock( StoreContext::class ) );
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'sequra_shopper_country' );
+		WC()->customer = $this->original_customer;
+	}
+
+	public function testGetCountry_orderWithShippingCountry_returnsShipping(): void {
+		$order = new WC_Order();
+		$order->set_shipping_country( 'PT' );
+		$order->set_billing_country( 'ES' );
+
+		$this->assertSame( 'PT', $this->shopper_service->get_country( $order ) );
+	}
+
+	public function testGetCountry_orderShippingEmpty_fallsBackToBilling(): void {
+		$order = new WC_Order();
+		$order->set_billing_country( 'ES' );
+
+		$this->assertSame( 'ES', $this->shopper_service->get_country( $order ) );
+	}
+
+	public function testGetCountry_sessionWithShippingCountry_returnsShipping(): void {
+		$customer = new WC_Customer();
+		$customer->set_shipping_country( 'FR' );
+		$customer->set_billing_country( 'ES' );
+		WC()->customer = $customer;
+
+		$this->assertSame( 'FR', $this->shopper_service->get_country( null ) );
+	}
+
+	public function testGetCountry_sessionShippingEmpty_fallsBackToBilling(): void {
+		$customer = new WC_Customer();
+		$customer->set_billing_country( 'IT' );
+		WC()->customer = $customer;
+
+		$this->assertSame( 'IT', $this->shopper_service->get_country( null ) );
+	}
+
+	public function testGetCountry_noCountryAnywhere_returnsEmpty(): void {
+		$order = new WC_Order();
+
+		$this->assertSame( '', $this->shopper_service->get_country( $order ) );
+	}
+
+	public function testGetCountry_filterOverridesResolvedCountry(): void {
+		$order = new WC_Order();
+		$order->set_shipping_country( 'ES' );
+
+		add_filter(
+			'sequra_shopper_country',
+			function () {
+				return 'PT';
+			}
+		);
+
+		$this->assertSame( 'PT', $this->shopper_service->get_country( $order ) );
+	}
+
+	public function testGetCountry_filterAppliesWhenNoCountryResolved(): void {
+		$order = new WC_Order();
+
+		add_filter(
+			'sequra_shopper_country',
+			function () {
+				return 'FR';
+			}
+		);
+
+		$this->assertSame( 'FR', $this->shopper_service->get_country( $order ) );
+	}
+}

--- a/sequra/tests/Services/Shopper/ShopperServiceTest.php
+++ b/sequra/tests/Services/Shopper/ShopperServiceTest.php
@@ -126,4 +126,16 @@ class ShopperServiceTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'California', $this->shopper_service->get_state( null ) );
 	}
+
+	public function testGetState_invoiceAddress_validatesStateAgainstBillingCountry(): void {
+		$order = new WC_Order();
+		$order->set_shipping_country( 'PT' );
+		$order->set_billing_country( 'US' );
+		$order->set_billing_state( 'CA' );
+
+		// With is_delivery = false the billing state must be validated against the
+		// billing country (US), not the shipping country (PT). Otherwise a valid
+		// billing state is silently dropped to '' when billing and shipping differ.
+		$this->assertSame( 'California', $this->shopper_service->get_state( $order, false ) );
+	}
 }

--- a/sequra/tests/Services/Shopper/ShopperServiceTest.php
+++ b/sequra/tests/Services/Shopper/ShopperServiceTest.php
@@ -109,4 +109,21 @@ class ShopperServiceTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'FR', $this->shopper_service->get_country( $order ) );
 	}
+
+	public function testGetCity_sessionShippingEmpty_fallsBackToBilling(): void {
+		$customer = new WC_Customer();
+		$customer->set_billing_city( 'Madrid' );
+		WC()->customer = $customer;
+
+		$this->assertSame( 'Madrid', $this->shopper_service->get_city( null ) );
+	}
+
+	public function testGetState_sessionShippingEmpty_fallsBackToBilling(): void {
+		$customer = new WC_Customer();
+		$customer->set_billing_country( 'US' );
+		$customer->set_billing_state( 'CA' );
+		WC()->customer = $customer;
+
+		$this->assertSame( 'California', $this->shopper_service->get_state( null ) );
+	}
 }

--- a/sequra/tests/Services/Shopper/ShopperServiceTest.php
+++ b/sequra/tests/Services/Shopper/ShopperServiceTest.php
@@ -83,6 +83,20 @@ class ShopperServiceTest extends WP_UnitTestCase {
 		$this->assertSame( 'PT', $this->shopper_service->get_country( $order ) );
 	}
 
+	public function testGetCountry_filterValueIsUppercased(): void {
+		$order = new WC_Order();
+		$order->set_shipping_country( 'ES' );
+
+		add_filter(
+			'sequra_shopper_country',
+			function () {
+				return 'pt';
+			}
+		);
+
+		$this->assertSame( 'PT', $this->shopper_service->get_country( $order ) );
+	}
+
 	public function testGetCountry_filterAppliesWhenNoCountryResolved(): void {
 		$order = new WC_Order();
 


### PR DESCRIPTION
### What is the goal?

Audit the shopper-country resolution across product pages, checkout gating, and order/solicitation building. Produce a documented resolution flow, identify and reconcile the divergent code paths and hidden defaults, and harden the behavior so the country used for **availability gating** and the country sent in the **solicitation** are consistent and predictable. Add the test coverage this fragile area currently lacks.

### References

- **Issue:** https://sequra.atlassian.net/browse/PAR-811

### Definition of done

1. [x] A written audit enumerates every country source and consumer, with the resolution flow and the identified inconsistencies.
1. [x] A single documented fallback policy for empty/unknown country, with the hardcoded `'ES'` default removed.
1. [x] The `sequra_shopper_country` filter is applied once, at a documented point.
1. [x] The shipping→billing fallback works in the guest/session checkout path, not only the order path.
1. [x] New unit tests cover the resolution order, the session billing fallback, the empty/fallback cases, and the filter; full suite passes.
1. [x] `bin/phpcs` and `bin/phpstan` pass for both plugins.

### How is it being implemented?

The audit found "shopper country" was resolved by three independent, inconsistent paths: the checkout/gating/solicitation resolver (`Shopper_Service::get_country`), the order-request builder (`Create_Order_Request_Builder::get_country`), and the widget resolver (`I18n::get_current_country`). They disagreed on the shipping→billing fallback, on whether the `sequra_shopper_country` filter applied, and on the empty-country default (hidden `'ES'`, double-applied filter, lowercase locale guess).

Surgical fixes (no shared resolver, per the agreed scope):

- **Session fallback:** `Shopper_Service::get_country()` now falls back shipping→billing in the guest/session path (the alt key was a bare field name the session never populates). The same broken pattern in `get_state()` / `get_city()` is fixed too.
- **Single filter point + casing:** the `sequra_shopper_country` filter is applied once in `Shopper_Service::get_country()` and the resolved country is uppercased (downstream merchant lookup and service gating are case-sensitive). The duplicate application in the order-request builder is removed.
- **Country fallback policy:** `Order_Address_Builder` no longer defaults a missing country to Spain. In the builder, an explicit filter override resolves first (Priority 1), then a previously-stored order country (Priority 2), and only as a last resort the locale (uppercased, Priority 3). The delivery/invoice address falls back to that same resolved solicitation country when the address itself has none — so it is never empty and never a hardcoded Spain, and the address and merchant countries stay consistent.
- **Widgets:** `I18n::get_current_country()` is documented as the widget-surface resolver and the single filter point for that surface.
- **Testability:** `Create_Order_Request_Builder::get_country()` is made `public` (not part of any interface, no external callers) so its resolution priorities can be unit-tested.

### Opportunistic refactorings

- Fixed a pre-existing, unrelated failure in `MigrationInstall300Test` (the sandbox test merchant now returns an extra `allow_authorize_and_capture` contract option) that was failing on master and blocking the pre-push test gate.
- Hardened `get_state()` / `get_city()`, which the audit found shared the same broken session fallback as the country.

### Caveats

- Behavior change: guest shoppers with a billing but no shipping country now resolve a country at checkout, so seQura may appear where it previously did not (e.g. virtual-only carts). Country gating still excludes unsupported countries.
- When the country cannot be resolved from the address/order/stored order, it falls back to the locale (uppercased) — never empty and never a hardcoded `'ES'`. An empty `country_code` was found (via E2E) to break the address-less service-selling flow, which is why the delivery/invoice address reuses the resolved solicitation country.
- The `sequra_shopper_country` filter now applies to the resolved address country at checkout; a filter-forced country is persisted in the stored order and recovered in the webhook flow.
- Widgets keep a separate source cascade from checkout (incl. a direct locale fallback); filter and uppercasing are aligned across both, but the cascades are not unified (documented known gap, per the surgical scope).

### How is it tested?

Automatic tests. New unit tests cover `Shopper_Service` (`get_country` matrix + `get_state`/`get_city` billing fallback), the address builder (no `'ES'` default + the resolved-country fallback), the widget resolver (`I18n::get_current_country`), and the builder `get_country` priorities (live / stored-order recovery / locale fallback). Full PHPUnit suite + `bin/phpcs` / `bin/phpstan` are green for both plugins. E2E checkout specs were run against the sandbox and pass: `001`/`002` (product) and `003` (service, address-less `addresses_may_be_missing` flow).

### How is it going to be deployed?

Standard deployment. The plugin header is set to `4.3.3-rc.1` for pre-release testing; the readme `Stable tag` and final `4.3.3` changelog are finalized at release time via the version-bump flow.
