### PR TITLE
[PAR-816] Include Fee Tax In Handling And Discount Items

### DIFF
--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -3,7 +3,7 @@ Contributors: sequradev
 Tags: woocommerce, payment gateway, BNPL, installments, buy now pay later
 Requires at least: 5.9
 Tested up to: 7.0.0
-Stable tag: 4.3.2
+Stable tag: 4.3.3
 Requires PHP: 7.3
 License: GPL-3.0+
 License URI: https://www.gnu.org/licenses/gpl-3.0.txt
@@ -104,6 +104,7 @@ Contributors:
 * Fixed: During guest checkout the shopper country now falls back from the shipping address to the billing address, so seQura no longer disappears when only a billing country is set.
 * Fixed: During guest checkout the shopper state and city now fall back from the shipping address to the billing address (matching the country), so the solicitation receives complete address data.
 * Fixed: The shopper country is normalized to uppercase (ISO-3166-1 alpha-2), so case differences no longer prevent payment methods from showing or the correct merchant from being selected.
+* Fixed: Taxes on checkout fees are now included in the amount sent to seQura, so the order total matches when a fee is taxable.
 * Changed: The order request no longer defaults a missing delivery or invoice country to Spain, and the sequra_shopper_country filter is now applied consistently to the resolved shopper country used for availability and the solicitation.
 = 4.3.2	=
 * Fixed: Locale detection now correctly prioritizes active multilingual plugins (Polylang, qTranslate, WPML) before falling back to the site or user locale.

--- a/sequra/sequra.php
+++ b/sequra/sequra.php
@@ -8,7 +8,7 @@
  * Plugin Name:       seQura
  * Plugin URI:        https://sequra.es/
  * Description:       seQura payment gateway for WooCommerce
- * Version:           4.3.3-rc.1
+ * Version:           4.3.3-rc.2
  * Author:            "seQura Tech" <wordpress@sequra.com>
  * Author URI:        https://sequra.com/
  * License:           GPL-3.0+

--- a/sequra/src/Services/Cart/class-cart-service.php
+++ b/sequra/src/Services/Cart/class-cart-service.php
@@ -492,7 +492,7 @@ class Cart_Service implements Interface_Cart_Service {
 			 * @var object $fee
 			 */
 			foreach ( $cart->get_fees() as $fee ) {
-				$total_with_tax = (float) ( $fee->total ?? 0 );
+				$total_with_tax = (float) ( $fee->total ?? 0 ) + (float) ( $fee->tax ?? 0 );
 				if ( $total_with_tax >= 0 ) {
 					// Fees with positive total are handling items.
 					continue;
@@ -534,7 +534,7 @@ class Cart_Service implements Interface_Cart_Service {
 					continue;
 				}
 
-				$total_with_tax = (float) ( $fee->get_total() ?? 0 );
+				$total_with_tax = (float) ( $fee->get_total() ?? 0 ) + (float) ( $fee->get_total_tax() ?? 0 );
 				if ( $total_with_tax >= 0 ) {
 					// Fees with positive total are handling items.
 					continue;

--- a/sequra/src/Services/Cart/class-cart-service.php
+++ b/sequra/src/Services/Cart/class-cart-service.php
@@ -412,7 +412,7 @@ class Cart_Service implements Interface_Cart_Service {
 			 * @var object $fee
 			 */
 			foreach ( WC()->cart->get_fees() as $fee ) {
-				$total_with_tax = (float) ( $fee->total ?? 0 );
+				$total_with_tax = (float) ( $fee->total ?? 0 ) + (float) ( $fee->tax ?? 0 );
 				if ( $total_with_tax <= 0 ) {
 					// Fees with negative total are discount items.
 					continue;
@@ -437,7 +437,7 @@ class Cart_Service implements Interface_Cart_Service {
 					continue;
 				}
 
-				$total_with_tax = (float) ( $fee->get_total() ?? 0 );
+				$total_with_tax = (float) ( $fee->get_total() ?? 0 ) + (float) ( $fee->get_total_tax() ?? 0 );
 				if ( $total_with_tax <= 0 ) {
 					// Fees with negative total are discount items.
 					continue;

--- a/sequra/tests/Services/Cart/CartServiceTest.php
+++ b/sequra/tests/Services/Cart/CartServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Tests for the Cart_Service class.
+ *
+ * @package    SeQura/WC
+ * @subpackage SeQura/WC/Tests
+ */
+
+namespace SeQura\WC\Tests\Services\Cart;
+
+use SeQura\WC\Services\Cart\Cart_Service;
+use SeQura\WC\Services\Log\Interface_Logger_Service;
+use SeQura\WC\Services\Pricing\Interface_Pricing_Service;
+use SeQura\WC\Services\Product\Interface_Product_Service;
+use SeQura\WC\Services\Shopper\Interface_Shopper_Service;
+use WP_UnitTestCase;
+use WC_Order;
+use WC_Order_Item_Fee;
+
+class CartServiceTest extends WP_UnitTestCase {
+
+	/** @var Cart_Service */
+	private $cart_service;
+
+	public function set_up(): void {
+		$product_service = $this->createMock( Interface_Product_Service::class );
+		$pricing_service = $this->createMock( Interface_Pricing_Service::class );
+		$logger          = $this->createMock( Interface_Logger_Service::class );
+		$shopper_service = $this->createMock( Interface_Shopper_Service::class );
+
+		$pricing_service->method( 'to_cents' )->willReturnCallback(
+			static function ( $amount ) {
+				return (int) round( $amount * 100 );
+			}
+		);
+
+		$this->cart_service = new Cart_Service( $product_service, $pricing_service, $logger, $shopper_service );
+	}
+
+	public function testHandlingItemIncludesFeeTax(): void {
+		$order = $this->make_order( array( $this->make_fee( '10.00', '2.10' ) ) );
+
+		$items = $this->cart_service->get_handling_items( $order );
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( 1210, $items[0]->getTotalWithTax() );
+	}
+
+	public function testDiscountItemIncludesFeeTax(): void {
+		$order = $this->make_order( array( $this->make_fee( '-10.00', '-2.10' ) ) );
+
+		$items = $this->cart_service->get_discount_items( $order );
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( -1210, $items[0]->getTotalWithTax() );
+	}
+
+	public function testZeroTaxFeeIsUnchanged(): void {
+		$order = $this->make_order( array( $this->make_fee( '10.00', '0' ) ) );
+
+		$items = $this->cart_service->get_handling_items( $order );
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( 1000, $items[0]->getTotalWithTax() );
+	}
+
+	/**
+	 * @param string $total Fee total without tax.
+	 * @param string $tax   Fee tax.
+	 * @return WC_Order_Item_Fee&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function make_fee( string $total, string $tax ) {
+		$fee = $this->createMock( WC_Order_Item_Fee::class );
+		$fee->method( 'get_total' )->willReturn( $total );
+		$fee->method( 'get_total_tax' )->willReturn( $tax );
+		$fee->method( 'get_name' )->willReturn( 'fee' );
+		return $fee;
+	}
+
+	/**
+	 * @param array<WC_Order_Item_Fee> $fees Fee items returned for the 'fee' item type.
+	 * @return WC_Order&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function make_order( array $fees ) {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_items' )->willReturnCallback(
+			static function ( $type = '' ) use ( $fees ) {
+				return 'fee' === $type ? $fees : array();
+			}
+		);
+		return $order;
+	}
+}


### PR DESCRIPTION
### What is the goal?

Add the fee tax to the amount reported for handling items (positive fees) and discount items (negative fees), in both the cart and the order code paths, mirroring the existing shipping pattern. This makes the sum of reported line items match the WooCommerce order total when a fee is taxable.

### References

- **Issue:** https://sequra.atlassian.net/browse/PAR-816

### Definition of done

1. [x] Handling and discount line items sent to seQura include the fee tax.
1. [x] For a cart/order containing a taxable fee, the sum of the reported line items equals the WooCommerce order total.
1. [x] Fees at 0% tax produce the same amounts as before (no regression).
1. [x] `bin/phpcs` and `bin/phpstan` pass.

### How is it being implemented?

The handling and discount line items are built in `Cart_Service::get_handling_items()` and `get_discount_items()`. Each fee amount was taken without its tax, while the order total already included it — so a taxable fee made the reported line items sum to less than the order total by exactly the fee tax. The fix adds the fee tax to the reported amount in all four spots (cart and order paths of both methods): `$fee->total + $fee->tax` for the cart, `$fee->get_total() + $fee->get_total_tax()` for the order, mirroring the shipping calculation that already adds its tax. The handling-vs-discount sign check now compares the tax-inclusive amount. No change to the integration-core package or to any consumer — they only forward the items.

### Caveats

The live-cart code path (`WC()->cart`) shares identical logic with the tested order path but is not covered by an automated test, as the repo has no fixture that bootstraps the cart global. It can be verified manually at checkout with a taxable fee.

### How is it tested?

Automatic tests: a new order-path unit test for the cart service asserts the reported handling and discount amounts include the fee tax (taxable positive fee → handling, taxable negative fee → discount), plus a zero-tax case guarding against regression. The full PHPUnit suite (207 tests), `bin/phpcs` and `bin/phpstan` all pass.

### How is it going to be deployed?

Standard deployment
