### PR TITLE
[PAR-817] PHP 8.5 Compatibility

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ npm run dev     # development: same, webpack dev mode with progress, non-minifie
 These wrap dockerized `php:8.4-cli-alpine` and run against **both** `sequra/` and `sequra-helper/`:
 
 ```bash
-bin/php-syntax-check --php=7.3   # syntax-lint across the supported PHP matrix (7.3–8.4)
+bin/php-syntax-check --php=7.3   # syntax-lint across the supported PHP matrix (7.3–8.5)
 bin/phpcs                        # PHPCS, standard .phpcs.xml.dist (WP coding standards)
 bin/phpcbf                       # auto-fix PHPCS violations
 bin/phpstan                      # PHPStan, config phpstan.neon, level set per project

--- a/sequra/readme.txt
+++ b/sequra/readme.txt
@@ -3,7 +3,7 @@ Contributors: sequradev
 Tags: woocommerce, payment gateway, BNPL, installments, buy now pay later
 Requires at least: 5.9
 Tested up to: 7.0.0
-Stable tag: 4.3.3
+Stable tag: 4.3.4
 Requires PHP: 7.3
 License: GPL-3.0+
 License URI: https://www.gnu.org/licenses/gpl-3.0.txt
@@ -100,6 +100,9 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 Contributors:
 == Changelog ==
+= 4.3.4	=
+* Added: Compatibility with PHP 8.5.
+
 = 4.3.3	=
 * Fixed: During guest checkout the shopper country now falls back from the shipping address to the billing address, so seQura no longer disappears when only a billing country is set.
 * Fixed: During guest checkout the shopper state and city now fall back from the shipping address to the billing address (matching the country), so the solicitation receives complete address data.

--- a/sequra/sequra.php
+++ b/sequra/sequra.php
@@ -8,7 +8,7 @@
  * Plugin Name:       seQura
  * Plugin URI:        https://sequra.es/
  * Description:       seQura payment gateway for WooCommerce
- * Version:           4.3.4
+ * Version:           4.3.4-rc.1
  * Author:            "seQura Tech" <wordpress@sequra.com>
  * Author URI:        https://sequra.com/
  * License:           GPL-3.0+

--- a/sequra/sequra.php
+++ b/sequra/sequra.php
@@ -8,7 +8,7 @@
  * Plugin Name:       seQura
  * Plugin URI:        https://sequra.es/
  * Description:       seQura payment gateway for WooCommerce
- * Version:           4.3.3
+ * Version:           4.3.4
  * Author:            "seQura Tech" <wordpress@sequra.com>
  * Author URI:        https://sequra.com/
  * License:           GPL-3.0+


### PR DESCRIPTION
### What is the goal?

Verify the plugin is compatible with PHP 8.5 and lock that verification into CI. Extend the CI PHP syntax-lint matrix to include 8.5, run the plugin under a PHP 8.5 runtime to surface any deprecation notices or behavioral changes the parse-only lint cannot catch, and fix anything the plugin owns that breaks.

### References

- **Issue:** https://sequra.atlassian.net/browse/PAR-817

### Definition of done

- [x] `bin/php-syntax-check --php=8.5` exits 0.
- [x] CI syntax-lint matrix includes `8.5` and is green.
- [x] `bin/phpcs` and `bin/phpstan` pass.
- [x] The PHPUnit suite runs on a PHP 8.5 runtime with no failures and no plugin-originated deprecation notices.

### How is it being implemented?

- Added `8.5` to the `syntax-lint` matrix in `.github/workflows/php-qa.yml`; CI now parse-checks the plugin across PHP 7.3–8.5.
- Verified the plugin against a PHP 8.5 runtime (WordPress 7.0 image): the full PHPUnit suite is green and no PHP 8.5 deprecations originate from this plugin's code.
- No source changes were required — a static scan (implicit-nullable params, long-form casts, `each()`/`create_function`/`utf8_*`, `${}` interpolation) and the runtime run both came back clean.
- Bumped the plugin version to 4.3.4 (`sequra.php` header + `readme.txt` stable tag) and added a changelog entry noting PHP 8.5 compatibility. Minimum supported PHP stays 7.3.

### Caveats

- One PHP 8.5 deprecation (`curl_close()` is deprecated since 8.5) originates in the vendored `sequra/integration-core` package, not in this plugin. It is out of scope here and needs to be addressed upstream in the core library.

### How is it tested?

- Ran the full PHPUnit suite under PHP 8.5 (WordPress 7.0): **207 tests, 859 assertions, all passing**, with no plugin-originated deprecation notices.
- `bin/phpcs`, `bin/phpstan`, and `bin/php-syntax-check --php=8.5` all pass locally, and the 8.5 syntax-lint now runs in CI.

### How is it going to be deployed?

Standard deployment.
